### PR TITLE
Logging improvement for failed block traverse & resuming a traverse

### DIFF
--- a/EBA/Blockchains/Bitcoin/GraphModel/BitcoinGraph.cs
+++ b/EBA/Blockchains/Bitcoin/GraphModel/BitcoinGraph.cs
@@ -44,6 +44,6 @@ public class BitcoinGraph : GraphBase, IEquatable<BitcoinGraph>
 
     public override int GetHashCode()
     {
-        throw new NotImplementedException();
+        throw new NotImplementedException("BitcoinGraph.GetHashCode is not implemented.");
     }
 }

--- a/EBA/Blockchains/Bitcoin/GraphModel/BlockGraph.cs
+++ b/EBA/Blockchains/Bitcoin/GraphModel/BlockGraph.cs
@@ -166,7 +166,7 @@ public class BlockGraph : BitcoinGraph, IEquatable<BlockGraph>
         if (!equal)
             return false;
 
-        throw new NotImplementedException();
+        throw new NotImplementedException("Comparing BlockGraphs with different properties is not implemented.");
     }
 
     public override bool Equals(object? obj)
@@ -176,6 +176,6 @@ public class BlockGraph : BitcoinGraph, IEquatable<BlockGraph>
 
     public override int GetHashCode()
     {
-        throw new NotImplementedException();
+        throw new NotImplementedException("BlockGraph.GetHashCode is not implemented.");
     }
 }

--- a/EBA/Blockchains/Bitcoin/GraphModel/BlockNode.cs
+++ b/EBA/Blockchains/Bitcoin/GraphModel/BlockNode.cs
@@ -92,11 +92,11 @@ public class BlockNode(
 
     public int CompareTo(BlockNode? other)
     {
-        throw new NotImplementedException();
+        throw new NotImplementedException("BlockNode.CompareTo is not implemented.");
     }
 
     public bool Equals(BlockNode? other)
     {
-        throw new NotImplementedException();
+        throw new NotImplementedException("BlockNode.Equals is not implemented.");
     }
 }

--- a/EBA/Blockchains/Bitcoin/GraphModel/TxNode.cs
+++ b/EBA/Blockchains/Bitcoin/GraphModel/TxNode.cs
@@ -120,11 +120,11 @@ public class TxNode : Node, IComparable<TxNode>, IEquatable<TxNode>
 
     public int CompareTo(TxNode? other)
     {
-        throw new NotImplementedException();
+        throw new NotImplementedException("TxNode.CompareTo is not implemented.");
     }
 
     public bool Equals(TxNode? other)
     {
-        throw new NotImplementedException();
+        throw new NotImplementedException("TxNode.Equals is not implemented.");
     }
 }

--- a/EBA/CLI/Config/BitcoinTraverseOptions.cs
+++ b/EBA/CLI/Config/BitcoinTraverseOptions.cs
@@ -1,7 +1,18 @@
-﻿namespace EBA.CLI.Config;
+﻿using System.Text.Json.Serialization;
 
-public class BitcoinTraverseOptions(long timestamp)
+namespace EBA.CLI.Config;
+
+public class BitcoinTraverseOptions
 {
+    public BitcoinTraverseOptions(long timestamp)
+    {
+        BlocksToProcessListFilename = $"{timestamp}_bitcoin_blocks_to_process.eba";
+        BlocksFailedToProcessListFilename = $"{timestamp}_bitcoin_blocks_failed_to_process.eba";
+    }
+
+    [JsonConstructor]
+    public BitcoinTraverseOptions() { }
+    
     public Uri ClientUri
     {
         init
@@ -66,8 +77,8 @@ public class BitcoinTraverseOptions(long timestamp)
     }
     private int _granularity = 1;
 
-    public string BlocksToProcessListFilename { init; get; } = $"{timestamp}_bitcoin_blocks_to_process.eba";
-    public string BlocksFailedToProcessListFilename { init; get; } = $"{timestamp}_bitcoin_blocks_failed_to_process.eba";
+    public string BlocksToProcessListFilename { init; get; }
+    public string BlocksFailedToProcessListFilename { init; get; }
 
     public int MaxBlocksInBuffer { init; get; } = 100;
 

--- a/EBA/Graph/Bitcoin/BitcoinGraphOrchestrator.cs
+++ b/EBA/Graph/Bitcoin/BitcoinGraphOrchestrator.cs
@@ -29,7 +29,7 @@ public class BitcoinGraphOrchestrator : IGraphOrchestrator<BitcoinGraph>, IDispo
             GraphTraversal.FFS => new ForestFire(_options, _db, _logger),
             //GraphTraversal.BFS => throw new NotImplementedException(),
             //GraphTraversal.DFS => throw new NotImplementedException(),
-            _ => throw new NotImplementedException(),
+            _ => throw new NotImplementedException("Unsupported graph traversal algorithm."),
         };
 
         await sampler.SampleAsync(ct);

--- a/EBA/Graph/Bitcoin/OffChain/EconomicAugmentor.cs
+++ b/EBA/Graph/Bitcoin/OffChain/EconomicAugmentor.cs
@@ -102,7 +102,7 @@ public class EconomicAugmentor(Options options, IGraphDb<BitcoinGraph> graphDb, 
                 .MapRange(PropertyMappingFactory.ToMappings<BlockNode>(n => n.BlockMetadata.Ohlcv))
                 .ToArray());
 
-        _logger.LogInformation("Saving realized cap for {count:n0} block nodes.", blockNodes.Count);
+        _logger.LogInformation("Saving updated properties for {count:n0} block nodes.", blockNodes.Count);
         var updates = blockNodes.Values
             .Select(b => economicMappings.ToProperties(b))
             .ToList();

--- a/EBA/Graph/Db/Neo4jDb/Neo4jDb.cs
+++ b/EBA/Graph/Db/Neo4jDb/Neo4jDb.cs
@@ -157,17 +157,17 @@ public class Neo4jDb<T> : IGraphDb<T> where T : GraphBase
 
     public Task ImportAsync(CancellationToken ct, string batchName = "")
     {
-        throw new NotImplementedException();
+        throw new NotImplementedException("ImportAsync is not implemented.");
     }
 
     public void ReportQueries()
     {
-        throw new NotImplementedException();
+        throw new NotImplementedException("ReportQueries is not implemented.");
     }
 
     public Task SampleAsync(CancellationToken ct)
     {
-        throw new NotImplementedException();
+        throw new NotImplementedException("SampleAsync is not implemented.");
     }
 
     public async Task SerializeConstantsAndConstraintsAsync(CancellationToken ct)

--- a/EBA/Graph/Model/Edge.cs
+++ b/EBA/Graph/Model/Edge.cs
@@ -78,7 +78,7 @@ public class Edge<TSource, TTarget> : IEdge<TSource, TTarget>, IEquatable<Edge<T
 
     public void AddValue(long value)
     {
-        throw new NotImplementedException();
+        throw new NotImplementedException("Edge.AddValue is not implemented.");
     }
 
     public string GetHashCode(bool ignoreValue)

--- a/EBA/Graph/Model/GraphBase.cs
+++ b/EBA/Graph/Model/GraphBase.cs
@@ -77,21 +77,6 @@ public class GraphBase(string? id = null) : IEquatable<GraphBase>, IDisposable
         return _edges.ToImmutableDictionary(x => x.Key, x => x.Value.Values);
     }
 
-    public void GetNode(string id, out INode node) // TODO: you can change this to return node instead of void
-    {
-        foreach (var nodeTypes in _nodes)
-        {
-            nodeTypes.Value.TryGetValue(id, out var n);
-            if (n != null)
-            {
-                node = n;
-                return;
-            }
-        }
-
-        throw new NotImplementedException();
-    }
-
     public bool ContainsNode(string id)
     {
         foreach (var nodeTypes in _nodes)
@@ -257,7 +242,7 @@ public class GraphBase(string? id = null) : IEquatable<GraphBase>, IDisposable
     }
     public override int GetHashCode()
     {
-        throw new NotImplementedException();
+        throw new NotImplementedException("GraphBase.GetHashCode is not implemented.");
     }
 
     public void Dispose()

--- a/EBA/PersistentObject/PersistentGraphBuffer.cs
+++ b/EBA/PersistentObject/PersistentGraphBuffer.cs
@@ -78,7 +78,7 @@ public class PersistentGraphBuffer : PersistentObjectBase<BlockGraph>, IDisposab
 
     public override Task SerializeAsync(IEnumerable<BlockGraph> objs, CancellationToken cT)
     {
-        throw new NotImplementedException();
+        throw new NotImplementedException("SerializeAsync for multiple BlockGraphs is not implemented.");
     }
 
     public int GetBufferSize()


### PR DESCRIPTION
This PR implements the following improvements:

- Bug fix reading `*_status.json` file (used to resume a failed/aborted traverse).
- Add exception to all the `NotImplemented` exceptions.