### PR TITLE
Bug fix reading graph from neo4j 

### DIFF
--- a/EBA/Blockchains/Bitcoin/GraphModel/ScriptNode.cs
+++ b/EBA/Blockchains/Bitcoin/GraphModel/ScriptNode.cs
@@ -9,7 +9,7 @@ public class ScriptNode : Node, IComparable<ScriptNode>, IEquatable<ScriptNode>
 
     public ScriptType ScriptType { get; }
 
-    public string HexBase64 { get; } = string.Empty;
+    public string? HexBase64 { get; }
 
     public string SHA256Hash { get; }
 
@@ -17,7 +17,7 @@ public class ScriptNode : Node, IComparable<ScriptNode>, IEquatable<ScriptNode>
         string address,
         ScriptType scriptType,
         string sha256Hash,
-        string hexBase64 = "",
+        string? hexBase64 = null,
         double? originalIndegree = null,
         double? originalOutdegree = null,
         double? hopsFromRoot = null,

--- a/EBA/Graph/Bitcoin/Descriptors/BitcoinStrategyFactory.cs
+++ b/EBA/Graph/Bitcoin/Descriptors/BitcoinStrategyFactory.cs
@@ -243,7 +243,7 @@ public class BitcoinStrategyFactory : IStrategyFactory
         return (source, target) switch
         {
             (CoinbaseNode, TxNode v) => C2TEdgeDescriptor.Deserialize(v, properties),
-            (TxNode u, TxNode v) => T2TEdgeDescriptor.Deserialize(u, v, properties),
+            (TxNode u, TxNode v) => T2TEdgeDescriptor.Deserialize(u, v, properties, relationship.Type),
             (BlockNode u, TxNode v) => B2TEdgeDescriptor.Deserialize(u, v, properties),
             (TxNode u, ScriptNode v) => T2SEdgeDescriptor.Deserialize(u, v, properties),
             (ScriptNode u, TxNode v) => S2TEdgeDescriptor.Deserialize(u, v, properties),

--- a/EBA/Graph/Bitcoin/Descriptors/T2TEdgeDescriptor.cs
+++ b/EBA/Graph/Bitcoin/Descriptors/T2TEdgeDescriptor.cs
@@ -18,7 +18,8 @@ public class T2TEdgeDescriptor : IElementDescriptor<T2TEdge>
     public static T2TEdge Deserialize(
         TxNode source, 
         TxNode target, 
-        IReadOnlyDictionary<string, object> props)
+        IReadOnlyDictionary<string, object> props,
+        string relationType)
     {
         return new T2TEdge(
             source: source,
@@ -26,6 +27,6 @@ public class T2TEdgeDescriptor : IElementDescriptor<T2TEdge>
             timestamp: 0,
             blockHeight: _mapper.GetValue(e => e.BlockHeight, props),
             value: _mapper.GetValue(e => e.Value, props),
-            type: _mapper.GetValue(e => e.Relation, props));
+            type: Enum.Parse<RelationType>(relationType, ignoreCase: true)); 
     }
 }

--- a/EBA/Graph/Model/ElementMapper.cs
+++ b/EBA/Graph/Model/ElementMapper.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq.Expressions;
+﻿using Microsoft.Extensions.Primitives;
+using System.Linq.Expressions;
 
 namespace EBA.Graph.Model;
 
@@ -111,11 +112,7 @@ public class ElementMapper<T>
             throw new KeyNotFoundException(
                 $"No mapping found for property '{propertyName}'.");
 
-        return
-            _mappings[index].Deserialize<V>(properties)
-            ?? throw new InvalidOperationException(
-                $"The property '{propertyName}' returned null, " +
-                $"but the requested type '{typeof(V).Name}' does not accept nulls.");
+        return _mappings[index].Deserialize<V>(properties)!;
     }
 
     public Func<string[], TProperty> GetFieldParser<TProperty>(Expression<Func<T, TProperty>> e)


### PR DESCRIPTION
- Bug fix matching the nullability of a property with the properties dictionary retrieved from neo4j. Previous if a property was nullable, with null value, the properties dictionary in neo4j would not return a key for that property with null value, which would result in throwing an exception. This PR updates it such that if a property is nullable, a missing key/value in neo4j properties dictionary is acceptable. 

- Make HexBase64 property of script node nullable since this property is only set for specific node types. However, the current implementation sets the property to empty string, and neo4j does not define a property for a node if the given value is empty string, hence when reading from the database, the properties dictionary would not have a key for this property. To fix, the `HexBase64` is set nullable. 

- `T2TEdge` reads relationship type from properties dictionary, but relationship type is defined in `relationship.Type`. So the method is updated to pass `relationship.Type` to the deserializer to read relationship type. 