### PR TITLE
Optimize `traverse` performance 

### DIFF
--- a/EBA/Graph/Db/Neo4jDb/Neo4jDb.cs
+++ b/EBA/Graph/Db/Neo4jDb/Neo4jDb.cs
@@ -213,13 +213,15 @@ public class Neo4jDb<T> : IGraphDb<T> where T : GraphBase
             _batches = await Batch.DeserializeBatchesAsync(_options.Neo4j.BatchesFilename);
 
         if (_batches.Count == 0 || _batches[^1].GetMaxCount() >= _options.Neo4j.MaxEntitiesPerBatch)
+        {
             _batches.Add(new Batch(
                 _batches.Count.ToString(),
                 _options.WorkingDir,
                 _strategyFactory.NodeStrategies,
                 _strategyFactory.EdgeStrategies));
 
-        await Batch.SerializeBatchesAsync(_options.Neo4j.BatchesFilename, _batches);
+            await Batch.SerializeBatchesAsync(_options.Neo4j.BatchesFilename, _batches);
+        }
 
         return _batches[^1];
     }

--- a/EBA/Graph/Model/CodecBase.cs
+++ b/EBA/Graph/Model/CodecBase.cs
@@ -33,12 +33,33 @@ public class CodecBase<TElement> : IElementCodec
             _filename = filename;
             _writer?.Dispose();
 
-            if (_serializeCompressed)
-                _writer = new StreamWriter(new GZipStream(File.Create(_filename), CompressionLevel.Optimal));
-            else
-                _writer = new StreamWriter(_filename);
+            var bufferSize = 1 << 16; // 2^16 = 65536 --> 64KB
 
-            _writer.AutoFlush = true;
+            if (_serializeCompressed)
+            {
+                _writer = new StreamWriter(
+                    new GZipStream(
+                        new FileStream(
+                            _filename,
+                            FileMode.Create,
+                            FileAccess.Write,
+                            FileShare.None,
+                            bufferSize: bufferSize,
+                            FileOptions.Asynchronous | FileOptions.SequentialScan),
+                        CompressionLevel.Fastest,
+                        leaveOpen: false),
+                    Encoding.UTF8,
+                    bufferSize: bufferSize,
+                    leaveOpen: false);
+            }
+            else
+            {
+                _writer = new StreamWriter(
+                    _filename, 
+                    append: false,
+                    Encoding.UTF8,
+                    bufferSize: bufferSize);
+            }
         }
         return _writer;
     }
@@ -51,9 +72,23 @@ public class CodecBase<TElement> : IElementCodec
     public async Task WriteCsvAsync(IEnumerable<TElement> elements, string filename)
     {
         var writer = GetStreamWriter(filename);
-        foreach (var x in elements)
+        var mapper = Descriptor.Mapper;
+        
+        // This piece shows better performance in cpu profile compared to using one foreach loop.
+        if (elements is TElement[] eArray)
         {
-            await writer.WriteLineAsync(Descriptor.Mapper.ToCsvRow(x));
+            for (var i = 0; i < eArray.Length; i++)
+                mapper.WriteCsvRow(writer, eArray[i]);
+        }
+        else if (elements is List<TElement> eList)
+        {
+            for (var i = 0; i < eList.Count; i++)
+                mapper.WriteCsvRow(writer, eList[i]);
+        }
+        else
+        {
+            foreach (var x in elements)
+                mapper.WriteCsvRow(writer, x);
         }
     }
 
@@ -74,7 +109,16 @@ public class CodecBase<TElement> : IElementCodec
 
     public Task WriteCsvAsync<T>(IEnumerable<T> elements, string filename) where T : IGraphElement
     {
-        return WriteCsvAsync(elements.Cast<TElement>(), filename);
+        if (elements is IEnumerable<TElement> typed)
+            return WriteCsvAsync(typed, filename);
+
+        return WriteCsvAsync(CastIter(elements), filename);
+
+        static IEnumerable<TElement> CastIter(IEnumerable<T> src)
+        {
+            foreach (var e in src) 
+                yield return (TElement)(object)e!;
+        }
     }
 
     public void Dispose()

--- a/EBA/Graph/Model/ElementMapper.cs
+++ b/EBA/Graph/Model/ElementMapper.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.Primitives;
-using System.Linq.Expressions;
+﻿using System.Linq.Expressions;
 
 namespace EBA.Graph.Model;
 
@@ -14,7 +13,7 @@ public class ElementMapper<T>
         _mappings = mappings;
 
         _propertyIndices = new Dictionary<string, int>(_mappings.Length);
-        for (int i = 0; i < _mappings.Length; i++)
+        for (var i = 0; i < _mappings.Length; i++)
             _propertyIndices[_mappings[i].Property.Name] = i;
 
         _cachedCsvHeader = string.Join(
@@ -27,6 +26,18 @@ public class ElementMapper<T>
     public string ToCsvRow(T source)
     {
         return string.Join(Options.CsvDelimiter, _mappings.Select(m => m.SerializeValue(source)));
+    }
+
+    public void WriteCsvRow(TextWriter writer, T source)
+    {
+        for (var i = 0; i < _mappings.Length; i++)
+        {
+            if (i > 0)
+                writer.Write(Options.CsvDelimiter);
+
+            _mappings[i].WriteValue(writer, source);
+        }
+        writer.WriteLine();
     }
 
     public Dictionary<string, object?> ToProperties(T source)

--- a/EBA/Graph/Model/MappingBuilder.cs
+++ b/EBA/Graph/Model/MappingBuilder.cs
@@ -77,11 +77,16 @@ public class MappingBuilder<T>
 
     public MappingBuilder<T> Map<TProperty>(Expression<Func<T, TProperty>> e)
     {
+        // this was a hot path in cpu profiling, 
+        // so compiling it once and caching it to avoid repeated compilation,
+        // resulted in better performance.
+        var compiled = e.Compile();
+
         _mappings.Add(new PropertyMapping<T>(
             new Property(
                 MappingBuilder.GetPropertyName(e),
                 MappingBuilder.ToFieldType(typeof(TProperty))),
-            x => e.Compile()(x)
+            x => compiled(x)
         ));
 
         return this;

--- a/EBA/Graph/Model/PropertyMapping.cs
+++ b/EBA/Graph/Model/PropertyMapping.cs
@@ -52,7 +52,7 @@ public class PropertyMapping<T>
         if (value is not string && value is IEnumerable enumerable)
         {
             return string.Join(
-                ";", 
+                ";",
                 enumerable.Cast<object>().Select(x => x?.ToString() ?? string.Empty));
         }
 
@@ -76,7 +76,7 @@ public class PropertyMapping<T>
         if (typeof(V).IsArray)
         {
             var elementType = typeof(V).GetElementType()!;
-            
+
             if (rawValue is string csvString)
             {
                 var parts = csvString.Split(';');
@@ -84,14 +84,14 @@ public class PropertyMapping<T>
                 for (int i = 0; i < parts.Length; i++)
                     if (!string.IsNullOrEmpty(parts[i]))
                         array.SetValue(Convert.ChangeType(parts[i], elementType), i);
-                        
+
                 return (V)(object)array;
             }
             else if (rawValue is IList list)
             {
                 int count = 0;
                 for (int i = 0; i < list.Count; i++)
-                    if (list[i] is not null) 
+                    if (list[i] is not null)
                         count++;
 
                 var array = Array.CreateInstance(elementType, count);
@@ -115,13 +115,54 @@ public class PropertyMapping<T>
 
     public V? Deserialize<V>(IReadOnlyDictionary<string, object> properties)
     {
-        return properties.TryGetValue(Property.Name, out var value) 
-            ? ConvertValue<V>(value) 
+        return properties.TryGetValue(Property.Name, out var value)
+            ? ConvertValue<V>(value)
             : default;
     }
 
     public V? DeserializeCsv<V>(string stringValue)
     {
         return ConvertValue<V>(stringValue);
+    }
+
+    public void WriteValue(TextWriter w, T source)
+    {
+        var value = _propertySelector(source);
+        if (value is null)
+            return;
+
+        if (value is string s)
+        {
+            w.Write(s);
+            return;
+        }
+
+        if (value is IFormattable f)
+        {
+            w.Write(f.ToString(null, System.Globalization.CultureInfo.InvariantCulture));
+            return;
+        }
+
+        if (value is IEnumerable e)
+        {
+            var first = true;
+            foreach (var item in e)
+            {
+                if (!first)
+                    w.Write(';');
+
+                first = false;
+                if (item is null)
+                    continue;
+
+                if (item is IFormattable fi)
+                    w.Write(fi.ToString(null, System.Globalization.CultureInfo.InvariantCulture));
+                else
+                    w.Write(item.ToString());
+            }
+            return;
+        }
+
+        w.Write(value.ToString());
     }
 }


### PR DESCRIPTION
Some recent PRs did add changes to graph and batch traversal that resulted in a significant slow down of the `traverse` subcommand. Such that, its performance from ~80min until block 200k in v1, reduced to ~16h; the slow down is not even linear, because with more recent blocks that result in creating significantly more nodes and edges per block, the slowdown is in fact a blocker. 

We identified hot path after profiling for cpu usage, and have optimized a few of the hottest paths. These optimizations reduced the execution time to 13min! 