### PR TITLE
Remove UTF8 encoding hidden char in serialized files

### DIFF
--- a/EBA/Graph/Model/CodecBase.cs
+++ b/EBA/Graph/Model/CodecBase.cs
@@ -35,6 +35,9 @@ public class CodecBase<TElement> : IElementCodec
 
             var bufferSize = 1 << 16; // 2^16 = 65536 --> 64KB
 
+            // exclude BOM for UTF-8 (utf identifier) since it breaks Neo4j import. 
+            var encoding = new UTF8Encoding(false);
+
             if (_serializeCompressed)
             {
                 _writer = new StreamWriter(
@@ -48,7 +51,7 @@ public class CodecBase<TElement> : IElementCodec
                             FileOptions.Asynchronous | FileOptions.SequentialScan),
                         CompressionLevel.Fastest,
                         leaveOpen: false),
-                    Encoding.UTF8,
+                    encoding,
                     bufferSize: bufferSize,
                     leaveOpen: false);
             }
@@ -57,7 +60,7 @@ public class CodecBase<TElement> : IElementCodec
                 _writer = new StreamWriter(
                     _filename, 
                     append: false,
-                    Encoding.UTF8,
+                    encoding,
                     bufferSize: bufferSize);
             }
         }


### PR DESCRIPTION
The current stream writers use UTF8 encoding, and the current setup results in writers adding a hidden Byte Order Mark (BOM). For instance: 

```
> zcat edges_Block_Confirms_Tx.csv.gz | head -n 1 | hexdump -C

00000000  ef bb bf 31 30 09 64 33  61 64 33 39...  |...10.d3ad39...|
# ef bb bf is the BOM. The 31 30 is the hex for your 10
```

While this is totally valid and compatible with many readers, neo4j throws the following error where it is reading `?10` instead of `10` from the above hexdump. 

```
Invalid relationship in import data

edges_Block_Confirms_Tx.csv.gz: line 1

(?10:Block)-[Confirms]->(d3ad39fa52a89997ac7381c95eeffeaf40b66af7a57e9eba144be0a175a12b11:Tx) referring to missing node ?10
```

This PR fixes the above bug by using a UTF8 encoding set not to include the identifier in a created file.
