### PR TITLE
Add initial version of the MCP service

### DIFF
--- a/.github/workflows/graphdb-tests.yml
+++ b/.github/workflows/graphdb-tests.yml
@@ -1,0 +1,32 @@
+name: GraphDB Tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build-and-test:
+    name: Build and Test
+    # ubuntu-latest has Docker daemon pre-installed, 
+    # which is essential for Testcontainers to run Neo4j db.    
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+
+    - name: Setup .NET 10
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Restore dependencies
+      run: dotnet restore tests/AAB.EBA.GraphDb.Tests
+
+    - name: Build
+      run: dotnet build tests/AAB.EBA.GraphDb.Tests --no-restore --configuration Release
+
+    - name: Test
+      run: dotnet test tests/AAB.EBA.GraphDb.Tests --no-build --configuration Release --verbosity normal

--- a/.github/workflows/mcp-tests.yml
+++ b/.github/workflows/mcp-tests.yml
@@ -1,0 +1,30 @@
+name: MCP Tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build-and-test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+
+    - name: Setup .NET 10
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Restore dependencies
+      run: dotnet restore tests/AAB.EBA.MCP.Tests
+
+    - name: Build
+      run: dotnet build tests/AAB.EBA.MCP.Tests --no-restore --configuration Release
+
+    - name: Test
+      run: dotnet test tests/AAB.EBA.MCP.Tests --no-build --configuration Release --verbosity normal

--- a/EBA.sln
+++ b/EBA.sln
@@ -1,9 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31919.166
+# Visual Studio Version 18
+VisualStudioVersion = 18.5.11716.220
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EBA", "EBA\EBA.csproj", "{0B89033E-FA0B-4FA8-9668-688C5E30E410}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AAB.EBA.MCP", "src\AAB.EBA.MCP\AAB.EBA.MCP.csproj", "{86E5CBD9-A3CB-4AC4-8ED3-CEF22D9558AC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AAB.EBA.MCP.Tests", "tests\AAB.EBA.MCP.Tests\AAB.EBA.MCP.Tests.csproj", "{306AD9F1-1492-4662-BC54-5C1DAFFB48C2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AAB.EBA.GraphDb", "src\AAB.EBA.GraphDb\AAB.EBA.GraphDb.csproj", "{9B7FEB79-B977-4424-B7C3-B5F86B1400B6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AAB.EBA.GraphDb.Tests", "tests\AAB.EBA.GraphDb.Tests\AAB.EBA.GraphDb.Tests.csproj", "{A8F13202-6D53-4FC1-BBAF-3F68E0470944}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,8 +23,27 @@ Global
 		{0B89033E-FA0B-4FA8-9668-688C5E30E410}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0B89033E-FA0B-4FA8-9668-688C5E30E410}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0B89033E-FA0B-4FA8-9668-688C5E30E410}.Release|Any CPU.Build.0 = Release|Any CPU
+		{86E5CBD9-A3CB-4AC4-8ED3-CEF22D9558AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{86E5CBD9-A3CB-4AC4-8ED3-CEF22D9558AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{86E5CBD9-A3CB-4AC4-8ED3-CEF22D9558AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{86E5CBD9-A3CB-4AC4-8ED3-CEF22D9558AC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{306AD9F1-1492-4662-BC54-5C1DAFFB48C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{306AD9F1-1492-4662-BC54-5C1DAFFB48C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{306AD9F1-1492-4662-BC54-5C1DAFFB48C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{306AD9F1-1492-4662-BC54-5C1DAFFB48C2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9B7FEB79-B977-4424-B7C3-B5F86B1400B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9B7FEB79-B977-4424-B7C3-B5F86B1400B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9B7FEB79-B977-4424-B7C3-B5F86B1400B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9B7FEB79-B977-4424-B7C3-B5F86B1400B6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A8F13202-6D53-4FC1-BBAF-3F68E0470944}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A8F13202-6D53-4FC1-BBAF-3F68E0470944}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A8F13202-6D53-4FC1-BBAF-3F68E0470944}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A8F13202-6D53-4FC1-BBAF-3F68E0470944}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {67286C5D-C315-4646-AB5C-0FADEB158020}
 	EndGlobalSection
 EndGlobal

--- a/src/AAB.EBA.GraphDb/AAB.EBA.GraphDb.csproj
+++ b/src/AAB.EBA.GraphDb/AAB.EBA.GraphDb.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\EBA\EBA.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/AAB.EBA.GraphDb/IGraphDb.cs
+++ b/src/AAB.EBA.GraphDb/IGraphDb.cs
@@ -1,0 +1,22 @@
+﻿using EBA.Blockchains.Bitcoin.GraphModel;
+using Neo4j.Driver;
+
+namespace AAB.EBA.GraphDb;
+
+public interface IGraphDb : IDisposable, IAsyncDisposable
+{
+    public Task VerifyConnectivityAsync(CancellationToken ct);
+
+    public Task<INode?> GetNodeAsync(
+        NodeKind label,
+        string propertyKey,
+        string propertyValue,
+        CancellationToken ct);
+
+    public Task<List<IRelationship>> GetEdgesAsync(
+        NodeKind nodeKind,
+        string nodePropertyKey,
+        string nodePropertyValue,
+        CancellationToken ct,
+        int? queryLimit = null);
+}

--- a/src/AAB.EBA.GraphDb/Neo4jDb.cs
+++ b/src/AAB.EBA.GraphDb/Neo4jDb.cs
@@ -1,0 +1,143 @@
+﻿using EBA.Blockchains.Bitcoin.GraphModel;
+using EBA.CLI.Config;
+using Microsoft.Extensions.Logging;
+using Neo4j.Driver;
+
+namespace AAB.EBA.GraphDb;
+
+public class Neo4jDb : IGraphDb
+{
+    private readonly Options _options;
+    private readonly IDriver _driver;
+
+    private bool _disposed = false;
+    private readonly ILogger<Neo4jDb> _logger;
+
+    public Neo4jDb(Options options, ILogger<Neo4jDb> logger)
+    {
+        _options = options;
+        _logger = logger;
+
+        // As per suggestions at https://neo4j.com/blog/developer/neo4j-driver-best-practices
+        // reuse a driver rather than initializing a new instance per request.
+        _driver = GraphDatabase.Driver(
+            _options.Neo4j.Uri,
+            AuthTokens.Basic(_options.Neo4j.User, _options.Neo4j.Password));
+    }
+
+    public async Task VerifyConnectivityAsync(CancellationToken ct)
+    {
+        try
+        {
+            await _driver.VerifyConnectivityAsync();
+        }
+        catch (AggregateException)
+        {
+            throw;
+        }
+    }
+
+    public async Task<INode?> GetNodeAsync(
+        NodeKind label,
+        string propertyKey,
+        string propertyValue,
+        CancellationToken ct)
+    {
+        await VerifyConnectivityAsync(ct);
+
+        using var session = _driver.AsyncSession(x => x.WithDefaultAccessMode(AccessMode.Read));
+
+        var nodeVar = "n";
+
+        var records = await session.ExecuteReadAsync(async x =>
+        {
+            var q = 
+            $"MATCH ({nodeVar}:{label} " +
+            $"{{ {propertyKey}: \"{propertyValue}\" }}) " +
+            $"RETURN {nodeVar}";
+
+            _logger.LogDebug("Executing query: {q}", q);
+
+            var result = await x.RunAsync(q);
+
+            return await result.ToListAsync(cancellationToken: ct);
+        });
+
+        if (records.Count == 0)
+            return null;
+
+        if (records.Count > 1)
+            throw new InvalidOperationException(
+                $"Multiple nodes found with '{propertyKey}'='{propertyValue}'.");
+
+        if (!records[0].ContainsKey(nodeVar))
+            throw new InvalidOperationException(
+                $"Returned record does not contain expected node variable '{nodeVar}'.");
+
+        return records[0][nodeVar].As<INode>();
+    }
+
+    public async Task<List<IRelationship>> GetEdgesAsync(
+        NodeKind nodeKind,
+        string nodePropertyKey,
+        string nodePropertyValue,
+        CancellationToken ct,
+        int? queryLimit = null)
+    {
+        await VerifyConnectivityAsync(ct);
+
+        var query =
+            $"MATCH " +
+            $"(n:{nodeKind} {{ `{nodePropertyKey}`: \"{nodePropertyValue}\" }})" +
+            $"-[r]-" +
+            $"() " +
+            $"RETURN r";
+
+        if (queryLimit != null && queryLimit.Value > 0)
+            query += $" LIMIT {queryLimit.Value}";
+
+        using var session = _driver.AsyncSession(x => x.WithDefaultAccessMode(AccessMode.Read));
+
+        _logger.LogDebug("Executing query: {Query}", query);
+
+        var records = await session.ExecuteReadAsync(async x =>
+        {
+            var cursor = await x.RunAsync(query);
+            return await cursor.ToListAsync(cancellationToken: ct);
+        });
+
+        return [.. records.Select(record => record["r"].As<IRelationship>())];
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposed)
+        {
+            if (disposing)
+            { }
+
+            _disposed = true;
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await DisposeAsyncCore().ConfigureAwait(false);
+        Dispose(false);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual async ValueTask DisposeAsyncCore()
+    {
+        if (!_disposed)
+        {
+            _disposed = true;
+        }
+    }
+}

--- a/src/AAB.EBA.MCP/AAB.EBA.MCP.csproj
+++ b/src/AAB.EBA.MCP/AAB.EBA.MCP.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyTitle></AssemblyTitle>
+    <RootNamespace>$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
+    <StartupObject>AAB.EBA.MCP.Program</StartupObject>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
+    <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
+    <PackageReference Include="Neo4j.Driver" Version="6.0.0" />
+    <PackageReference Include="Serilog" Version="4.3.1" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\EBA\EBA.csproj" />
+    <ProjectReference Include="..\AAB.EBA.GraphDb\AAB.EBA.GraphDb.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/AAB.EBA.MCP/Blockchains/Bitcoin/BitcoinBlockTools.cs
+++ b/src/AAB.EBA.MCP/Blockchains/Bitcoin/BitcoinBlockTools.cs
@@ -1,0 +1,44 @@
+﻿using AAB.EBA.MCP.Infrastructure;
+using System.Text.Json;
+
+namespace AAB.EBA.MCP.Blockchains.Bitcoin;
+
+[McpServerToolType, Description(
+    "Tools for getting information about bitcoin blocks")]
+public class BitcoinBlockTools(BitcoinMcpService mcpService)
+{
+    private readonly BitcoinMcpService _mcpService = mcpService;
+
+    [McpServerTool, Description("Get information about a bitcoin block by its height.")]
+    public async Task<string> GetBlockInfo(
+        [Description("The block height to get info for")] long height,
+        [Description("Whether to include the median time of the block")] bool includeMedianTime = false,
+        [Description("Whether to include the transaction count of the block")] bool includeTxCount = false,
+        [Description("Whether to include the minted coins of the block")] bool includeMintedCoins = false,
+        [Description("Whether to include the burned coins of the block")] bool includeBurnedCoins = false,
+        [Description("Whether to include the total supply of the block")] bool includeTotalSupply = false)
+    {
+        var blockNode = await _mcpService.GetBlockByHeightAsync(height);
+        if (blockNode == null)
+            return $"Block at height {height} not found.";
+
+        var responsePayload = new Dictionary<string, object>();
+
+        if (includeMedianTime)
+            responsePayload["MedianTime"] = blockNode.BlockMetadata.MedianTime;
+
+        if (includeTxCount)
+            responsePayload["TxCount"] = blockNode.BlockMetadata.TransactionsCount;
+
+        if (includeMintedCoins)
+            responsePayload["MintedCoins"] = blockNode.BlockMetadata.MintedBitcoins;
+
+        if (includeBurnedCoins)
+            responsePayload["BurnedCoins"] = blockNode.BlockMetadata.ProvablyUnspendableBitcoins;
+
+        if (includeTotalSupply)
+            responsePayload["TotalSupply"] = blockNode.BlockMetadata.TotalSupply?.ToString() ?? "";
+
+        return JsonSerializer.Serialize(responsePayload, McpJsonOptions.Default);
+    }
+}

--- a/src/AAB.EBA.MCP/Blockchains/Bitcoin/BitcoinMcpService.cs
+++ b/src/AAB.EBA.MCP/Blockchains/Bitcoin/BitcoinMcpService.cs
@@ -42,7 +42,6 @@ public class BitcoinMcpService(IGraphDb db)
         return ScriptNodeDescriptor.Deserialize(node.Properties, null, null, null, null);
     }
 
-    // test with DLy2CSDGtuqFpdeyUZn7nx12viBEu97HNw34jQ5StRrV
     public async Task<long?> GetScriptBalanceAsync(
         string sha, 
         long height = long.MaxValue, 

--- a/src/AAB.EBA.MCP/Blockchains/Bitcoin/BitcoinMcpService.cs
+++ b/src/AAB.EBA.MCP/Blockchains/Bitcoin/BitcoinMcpService.cs
@@ -1,0 +1,165 @@
+﻿using AAB.EBA.GraphDb;
+using EBA.Blockchains.Bitcoin.GraphModel;
+using EBA.Graph.Bitcoin.Descriptors;
+using EBA.Graph.Model;
+
+namespace AAB.EBA.MCP.Blockchains.Bitcoin;
+
+public class BitcoinMcpService(IGraphDb db)
+{
+    private readonly IGraphDb _db = db;
+
+    private static readonly BlockNodeDescriptor _blockNodeDescriptor = new();
+    private static readonly Property _blockNodeHeightProp = _blockNodeDescriptor.Mapper.GetMapping(x => x.BlockMetadata.Height).Property;
+
+    private static readonly ScriptNodeDescriptor _scriptNodeDescriptor = new();
+    private static readonly Property _addressProp = _scriptNodeDescriptor.Mapper.GetMapping(x => x.Address).Property;
+    private static readonly Property _sha256Prop = _scriptNodeDescriptor.Mapper.GetMapping(x => x.SHA256Hash).Property;
+
+    private static readonly ElementMapper<T2SEdge> _t2sMapper = T2SEdgeDescriptor.StaticMapper;
+
+    public async Task<ScriptNode?> GetScriptByAddressAsync(
+        string address, 
+        CancellationToken ct = default)
+    {
+        var node = await _db.GetNodeAsync(NodeKind.Script, _addressProp.Name, address, ct);
+
+        if (node == null)
+            return null;
+
+        return ScriptNodeDescriptor.Deserialize(node.Properties, null, null, null, null);
+    }
+
+    public async Task<ScriptNode?> GetScriptBySHA256Async(
+        string sha, 
+        CancellationToken ct = default)
+    {
+        var node = await _db.GetNodeAsync(NodeKind.Script, _sha256Prop.Name, sha, ct);
+
+        if (node == null)
+            return null;
+
+        return ScriptNodeDescriptor.Deserialize(node.Properties, null, null, null, null);
+    }
+
+    // test with DLy2CSDGtuqFpdeyUZn7nx12viBEu97HNw34jQ5StRrV
+    public async Task<long?> GetScriptBalanceAsync(
+        string sha, 
+        long height = long.MaxValue, 
+        CancellationToken ct = default)
+    {
+        var edges = await _db.GetEdgesAsync(NodeKind.Script, _sha256Prop.Name, sha, ct);
+
+        if (edges == null || edges.Count == 0)
+            return null;
+
+        var sortedEdges = edges.SortByRelevantHeight();
+        long balance = 0;
+        foreach (var edge in sortedEdges)
+        {
+            var creationH = _t2sMapper.GetValue(x => x.CreationHeight, edge.Properties);
+            var spentH = _t2sMapper.GetValue(x => x.SpentHeight, edge.Properties);
+
+            if (creationH > height)
+                break;
+
+            if (edge.Type == T2SEdge.Kind.Relation.ToString() && spentH == long.MaxValue)
+            {
+                balance += _t2sMapper.GetValue(x => x.Value, edge.Properties);
+            }
+        }
+
+        return balance;
+    }
+
+    public async Task<ScriptTxSummaryStats?> GetScriptTxSummaryStatsAsync(
+        string sha, 
+        CancellationToken ct = default)
+    {
+        var edges = await _db.GetEdgesAsync(NodeKind.Script, _sha256Prop.Name, sha, ct);
+
+        if (edges == null || edges.Count == 0)
+            return null;
+
+        var sortedEdges = edges.SortByRelevantHeight();
+        long totalReceived = 0;
+        long totalSent = 0;
+        bool firstReceivedSet = false;
+        long firstReceivedValue = 0;
+        long firstReceivedHeight = long.MaxValue;
+        long lastReceivedValue = long.MaxValue;
+        long lastReceivedHeight = long.MaxValue;
+
+        bool firstSentSet = false;
+        long firstSentValue = 0;
+        long firstSentHeight = long.MaxValue;
+        long lastSentValue = long.MaxValue;
+        long lastSentHeight = long.MaxValue;
+
+        long v = 0;
+        long h = 0;
+        foreach (var edge in sortedEdges)
+        {
+            if (edge.Type == T2SEdge.Kind.Relation.ToString())
+            {
+                v = _t2sMapper.GetValue(x => x.Value, edge.Properties);
+                h = _t2sMapper.GetValue(x => x.CreationHeight, edge.Properties);
+
+                totalReceived += v;
+
+                if (!firstReceivedSet)
+                {
+                    firstReceivedValue = v;
+                    firstReceivedHeight = h;
+                    firstReceivedSet = true;
+                }
+
+                lastReceivedValue = v;
+                lastReceivedHeight = h;
+            }
+            else if (edge.Type == S2TEdge.Kind.Relation.ToString())
+            {
+                v = _t2sMapper.GetValue(x => x.Value, edge.Properties);
+                h = _t2sMapper.GetValue(x => x.CreationHeight, edge.Properties);
+
+                totalSent += v;
+
+                if (!firstSentSet)
+                {
+                    firstSentValue = v;
+                    firstSentHeight = h;
+                    firstSentSet = true;
+                }
+
+                lastSentValue = v;
+                lastSentHeight = h;
+            }
+        }
+
+        return new ScriptTxSummaryStats(
+            TxCount: edges.Count,
+            TotalReceived: totalReceived,
+            TotalSent: totalSent,
+            FirstReceivedHeight: firstReceivedHeight,
+            FirstReceivedValue: firstReceivedValue,
+            FirstSentHeight: firstSentHeight,
+            FirstSentValue: firstSentValue,
+            LastReceivedHeight: lastReceivedHeight,
+            LastReceivedValue: lastReceivedValue,
+            LastSentHeight: lastSentHeight,
+            LastSentValue: lastSentValue
+        );
+    }
+
+    public async Task<BlockNode?> GetBlockByHeightAsync(
+        long height, 
+        CancellationToken ct = default)
+    {
+        var node = await _db.GetNodeAsync(NodeKind.Block, _blockNodeHeightProp.Name, height.ToString(), ct);
+
+        if (node == null)
+            return null;
+
+        return BlockNodeDescriptor.Deserialize(node.Properties, null, null, null, null);
+    }
+}

--- a/src/AAB.EBA.MCP/Blockchains/Bitcoin/BitcoinScriptTools.cs
+++ b/src/AAB.EBA.MCP/Blockchains/Bitcoin/BitcoinScriptTools.cs
@@ -1,0 +1,73 @@
+﻿using AAB.EBA.MCP.Infrastructure;
+using EBA.Blockchains.Bitcoin.GraphModel;
+using System.Text.Json;
+
+namespace AAB.EBA.MCP.Blockchains.Bitcoin;
+
+[McpServerToolType, Description(
+    "Tools for getting information about bitcoin addresses and scripts.")]
+public class BitcoinScriptTools(BitcoinMcpService mcpService)
+{
+    private readonly BitcoinMcpService _mcpService = mcpService;
+
+    [McpServerTool, Description(
+        "Get a bitcoin script/address by its address or SHA256 hash, " +
+        "returns the script type and SHA256 hash and optionally the balance.")]
+    public async Task<string> GetScript(
+        [Description("The address of the bitcoin script")] string? address = null,
+        [Description("The SHA256 hash of the bitcoin script")] string? sha = null,
+        [Description("[Optional, default false] Whether to include the balance of the script")] bool includeBalance = false,
+        [Description("[Optional, default latest] Block height to get the balance at; if includeBalance is true.")] long? block = null)
+    {
+        ScriptNode? scriptNode;
+
+        if (address != null)
+            scriptNode = await _mcpService.GetScriptByAddressAsync(address);
+        else if (sha != null)
+            scriptNode = await _mcpService.GetScriptBySHA256Async(sha);
+        else
+            return "Either address or SHA256 hash must be provided.";
+
+        if (scriptNode == null)
+            return $"Did not find a script with given address: {address}";
+
+        var responsePayload = new Dictionary<string, object>
+        {
+            { "ScriptType", scriptNode.ScriptType.ToString() },
+            { "SHA256Hash", scriptNode.SHA256Hash }
+        };
+
+        if (includeBalance)
+        {
+            var balance = await _mcpService.GetScriptBalanceAsync(scriptNode.SHA256Hash, block ?? long.MaxValue);
+            responsePayload.Add("Balance", balance);
+        }
+
+        return JsonSerializer.Serialize(responsePayload, McpJsonOptions.Default);
+    }
+
+    [McpServerTool, Description("Get detailed info about a script's transactions.")]
+    public async Task<string> GetScriptTxInfo(
+        [Description("The address of the bitcoin script")] string? address = null,
+        [Description("The SHA256 hash of the bitcoin script")] string? sha = null)
+    {
+        ScriptNode? scriptNode;
+
+        if (address != null)
+            scriptNode = await _mcpService.GetScriptByAddressAsync(address);
+        else if (sha != null)
+            scriptNode = await _mcpService.GetScriptBySHA256Async(sha);
+        else
+            return "Either address or SHA256 hash must be provided.";
+
+        if (scriptNode == null)
+            return $"Did not find a script with given address: {address}";
+
+        var stats = await _mcpService.GetScriptTxSummaryStatsAsync(sha);
+
+        if (stats == null)
+            return $"No transactions found for script with SHA256 hash: {sha}";
+
+        return JsonSerializer.Serialize(stats, McpJsonOptions.Default);
+    }
+}

--- a/src/AAB.EBA.MCP/Blockchains/Bitcoin/DTO.cs
+++ b/src/AAB.EBA.MCP/Blockchains/Bitcoin/DTO.cs
@@ -1,0 +1,15 @@
+﻿namespace AAB.EBA.MCP.Blockchains.Bitcoin;
+
+public record ScriptTxSummaryStats(
+    int TxCount,
+    long TotalReceived,
+    long TotalSent,
+    long FirstReceivedHeight,
+    long FirstReceivedValue,
+    long FirstSentHeight,
+    long FirstSentValue,
+    long LastReceivedHeight,
+    long LastReceivedValue,
+    long LastSentHeight,
+    long LastSentValue
+);

--- a/src/AAB.EBA.MCP/EdgeSortingExtensions.cs
+++ b/src/AAB.EBA.MCP/EdgeSortingExtensions.cs
@@ -15,7 +15,7 @@ public static class EdgeSortingExtensions
         string t2sRelation = T2SEdge.Kind.Relation.ToString();
         string s2tRelation = S2TEdge.Kind.Relation.ToString();
 
-        return edges.OrderBy(edge =>
+        return [.. edges.OrderBy(edge =>
         {
             if (edge.Type == t2sRelation)
             {
@@ -29,6 +29,6 @@ public static class EdgeSortingExtensions
 
             // Fallback for any unknown edge types to push them to the end
             return long.MaxValue;
-        }).ToList();
+        })];
     }
 }

--- a/src/AAB.EBA.MCP/EdgeSortingExtensions.cs
+++ b/src/AAB.EBA.MCP/EdgeSortingExtensions.cs
@@ -1,0 +1,34 @@
+﻿using EBA.Blockchains.Bitcoin.GraphModel;
+using Neo4j.Driver;
+
+namespace AAB.EBA.MCP;
+
+public static class EdgeSortingExtensions
+{
+    /// <summary>
+    /// Sorts a mixed collection of Neo4j edges chronologically. 
+    /// Uses CreationHeight for T2S edges and SpentHeight for S2T edges.
+    /// </summary>
+    public static List<IRelationship> SortByRelevantHeight(this IEnumerable<IRelationship> edges)
+    {
+        // Cache the relation types outside the loop for performance
+        string t2sRelation = T2SEdge.Kind.Relation.ToString();
+        string s2tRelation = S2TEdge.Kind.Relation.ToString();
+
+        return edges.OrderBy(edge =>
+        {
+            if (edge.Type == t2sRelation)
+            {
+                return edge.Properties[nameof(T2SEdge.CreationHeight)].As<long>();
+            }
+
+            if (edge.Type == s2tRelation)
+            {
+                return edge.Properties[nameof(S2TEdge.SpentHeight)].As<long>();
+            }
+
+            // Fallback for any unknown edge types to push them to the end
+            return long.MaxValue;
+        }).ToList();
+    }
+}

--- a/src/AAB.EBA.MCP/GlobalUsings.cs
+++ b/src/AAB.EBA.MCP/GlobalUsings.cs
@@ -1,0 +1,6 @@
+﻿global using Microsoft.Extensions.DependencyInjection;
+global using Microsoft.Extensions.Hosting;
+global using Microsoft.Extensions.Logging;
+global using ModelContextProtocol.Server;
+global using System.ComponentModel;
+global using System.Text.Json.Serialization;

--- a/src/AAB.EBA.MCP/Infrastructure/JsonOptions.cs
+++ b/src/AAB.EBA.MCP/Infrastructure/JsonOptions.cs
@@ -1,0 +1,20 @@
+﻿using System.Text.Json;
+
+namespace AAB.EBA.MCP.Infrastructure;
+
+public static class McpJsonOptions
+{
+    public static readonly JsonSerializerOptions Default = new()
+    {
+        Converters = { new JsonStringEnumConverter() },
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    public static readonly JsonSerializerOptions Compact = new()
+    {
+        Converters = { new JsonStringEnumConverter() },
+        WriteIndented = false,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}

--- a/src/AAB.EBA.MCP/Infrastructure/Startup.cs
+++ b/src/AAB.EBA.MCP/Infrastructure/Startup.cs
@@ -6,7 +6,7 @@ using EBA.Graph.Db.Neo4jDb;
 using Microsoft.Extensions.Configuration;
 using Serilog;
 
-namespace AAB.EBA.MCP.Infrastructure.StartupSolutions;
+namespace AAB.EBA.MCP.Infrastructure;
 
 public class Startup
 {

--- a/src/AAB.EBA.MCP/Infrastructure/StartupSolutions/Startup.cs
+++ b/src/AAB.EBA.MCP/Infrastructure/StartupSolutions/Startup.cs
@@ -1,0 +1,88 @@
+﻿using AAB.EBA.GraphDb;
+using AAB.EBA.MCP.Blockchains.Bitcoin;
+using EBA.CLI.Config;
+using EBA.Graph.Bitcoin.Descriptors;
+using EBA.Graph.Db.Neo4jDb;
+using Microsoft.Extensions.Configuration;
+using Serilog;
+
+namespace AAB.EBA.MCP.Infrastructure.StartupSolutions;
+
+public class Startup
+{
+    public static HostBuilder GetHostBuilder(Options options)
+    {
+        var hostBuilder = new HostBuilder();
+
+        var logFilename = options.Logger.LogFilename;
+
+        Log.Logger =
+            new LoggerConfiguration()
+            .MinimumLevel.Information()
+            .MinimumLevel.Override(
+                "System.Net.Http.HttpClient",
+                Serilog.Events.LogEventLevel.Warning)
+            .Enrich.FromLogContext()
+            .WriteTo.File(
+                path: logFilename,
+                rollingInterval: RollingInterval.Hour,
+                outputTemplate: options.Logger.MessageTemplate,
+                shared: true,
+                retainedFileCountLimit: null)
+            /*.WriteTo.Console(
+                theme: AnsiConsoleTheme.Code)*/
+            .CreateLogger();
+        hostBuilder.UseSerilog();
+
+        hostBuilder.ConfigureAppConfiguration(
+            (hostingContext, configuration) =>
+            {
+                ConfigureApp(hostingContext, configuration, options);
+            });
+
+        hostBuilder.ConfigureServices(
+            services =>
+            {
+                ConfigureServices(services, options);
+            });
+
+        return hostBuilder;
+    }
+
+    private static void ConfigureApp(
+        HostBuilderContext context,
+        IConfigurationBuilder config,
+        Options options)
+    {
+        config.Sources.Clear();
+        var env = context.HostingEnvironment;
+
+        config
+            .SetBasePath(env.ContentRootPath)
+            .AddJsonFile(
+                $"appsettings.json",
+                optional: true,
+                reloadOnChange: true)
+            .AddJsonFile(
+                $"appsettings.{env.EnvironmentName}.json",
+                optional: true,
+                reloadOnChange: true);
+
+        var configRoot = config.Build();
+        configRoot.GetSection(nameof(Options)).Bind(options);
+    }
+
+    private static void ConfigureServices(IServiceCollection services, Options options)
+    {
+        services.AddSingleton(options);
+        services.AddSingleton<BitcoinMcpService>();
+        services.AddSingleton<IStrategyFactory, BitcoinStrategyFactory>();
+        services.AddSingleton<IGraphDb, Neo4jDb>();
+
+        services.AddHttpClient();
+
+        services.AddMcpServer()
+            .WithStdioServerTransport()
+            .WithToolsFromAssembly();
+    }
+}

--- a/src/AAB.EBA.MCP/Orchestrator.cs
+++ b/src/AAB.EBA.MCP/Orchestrator.cs
@@ -1,0 +1,54 @@
+﻿using AAB.EBA.MCP.Infrastructure.StartupSolutions;
+using EBA.CLI.Config;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
+
+namespace AAB.EBA.MCP;
+
+public class Orchestrator : IDisposable
+{
+    private ILogger? _logger;
+    private readonly CancellationToken _cT;
+
+    private bool _disposed = false;
+
+    public Orchestrator(CancellationToken cT)
+    {
+        _cT = cT;
+    }
+
+    public async Task<int> InvokeAsync(string[] args)
+    {
+        var options = new Options();
+        var host = await SetupAndGetHostAsync(options);
+
+        await host.RunAsync(_cT);
+
+        return 0;
+    }
+
+    private async Task<IHost> SetupAndGetHostAsync(Options options)
+    {
+        Directory.CreateDirectory(options.WorkingDir);
+        var hostBuilder = Startup.GetHostBuilder(options);
+        var host = hostBuilder.Build();
+        _logger = host.Services.GetRequiredService<ILogger<Orchestrator>>();
+
+        return host;
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposed)
+        {
+            if (disposing)
+            { }
+
+            _disposed = true;
+        }
+    }
+}

--- a/src/AAB.EBA.MCP/Orchestrator.cs
+++ b/src/AAB.EBA.MCP/Orchestrator.cs
@@ -1,4 +1,4 @@
-﻿using AAB.EBA.MCP.Infrastructure.StartupSolutions;
+﻿using AAB.EBA.MCP.Infrastructure;
 using EBA.CLI.Config;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
 

--- a/src/AAB.EBA.MCP/Program.cs
+++ b/src/AAB.EBA.MCP/Program.cs
@@ -1,0 +1,69 @@
+﻿using Serilog;
+
+namespace AAB.EBA.MCP;
+
+internal class Program
+{
+    private static readonly CancellationTokenSource _tokenSource = new();
+
+    static async Task<int> Main(string[] args)
+    {
+        var cancellationToken = _tokenSource.Token;
+
+        var exitCode = 0;
+
+        try
+        {
+            var logger = Log.Logger;
+            var orchestrator = new Orchestrator(cancellationToken);
+            Console.CancelKeyPress += (sender, e) =>
+            {
+                // Flag the cancel token so all listening can exit ASAP.
+                _tokenSource.Cancel();
+
+                // Prevents the console from exiting immediately.
+                e.Cancel = true;
+
+                logger.Information("Cancelling...");
+            };
+
+            exitCode = await orchestrator.InvokeAsync(args);
+
+            if (exitCode == 0)
+                logger.Information("All process finished!");
+        }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine(e.Message);
+            exitCode = 1;
+        }
+
+        // Do not enable the following as it causes issues with building migration scripts.
+        //Environment.Exit(exitCode);
+        return exitCode;
+    }
+}
+
+
+
+
+
+
+
+
+
+public partial class Monkey
+{
+    public string? Name { get; set; }
+    public string? Location { get; set; }
+    public string? Details { get; set; }
+    public string? Image { get; set; }
+    public int Population { get; set; }
+    public double Latitude { get; set; }
+    public double Longitude { get; set; }
+}
+
+[JsonSerializable(typeof(List<Monkey>))]
+internal sealed partial class MonkeyContext : JsonSerializerContext
+{
+}

--- a/src/AAB.EBA.MCP/Program.cs
+++ b/src/AAB.EBA.MCP/Program.cs
@@ -43,27 +43,3 @@ internal class Program
         return exitCode;
     }
 }
-
-
-
-
-
-
-
-
-
-public partial class Monkey
-{
-    public string? Name { get; set; }
-    public string? Location { get; set; }
-    public string? Details { get; set; }
-    public string? Image { get; set; }
-    public int Population { get; set; }
-    public double Latitude { get; set; }
-    public double Longitude { get; set; }
-}
-
-[JsonSerializable(typeof(List<Monkey>))]
-internal sealed partial class MonkeyContext : JsonSerializerContext
-{
-}

--- a/src/AAB.EBA.MCP/README.md
+++ b/src/AAB.EBA.MCP/README.md
@@ -1,0 +1,3 @@
+```
+npx @modelcontextprotocol/inspector dotnet AAB.EBA.MCP.dll
+```

--- a/tests/AAB.EBA.GraphDb.Tests/AAB.EBA.GraphDb.Tests.csproj
+++ b/tests/AAB.EBA.GraphDb.Tests/AAB.EBA.GraphDb.Tests.csproj
@@ -1,0 +1,35 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Testcontainers.Neo4j" Version="4.11.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\EBA\EBA.csproj" />
+    <ProjectReference Include="..\..\src\AAB.EBA.GraphDb\AAB.EBA.GraphDb.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/AAB.EBA.GraphDb.Tests/BitcoinGraphScenarios.cs
+++ b/tests/AAB.EBA.GraphDb.Tests/BitcoinGraphScenarios.cs
@@ -1,0 +1,44 @@
+﻿using EBA.Blockchains.Bitcoin.ChainModel;
+using EBA.Blockchains.Bitcoin.GraphModel;
+using EBA.Graph.Model;
+
+namespace AAB.EBA.GraphDb.Tests;
+
+public static class BitcoinGraphScenarios
+{
+    public static GraphBase GetCommunity1()
+    {
+        var g = new GraphBase();
+
+        var b10 = new BlockNode(new Block() { Height = 10, MedianTime = 1 });
+        var b20 = new BlockNode(new Block() { Height = 20, MedianTime = 2 });
+        var b30 = new BlockNode(new Block() { Height = 30, MedianTime = 3 });
+        var b50 = new BlockNode(new Block() { Height = 50, MedianTime = 5 });
+
+        var s1 = new ScriptNode(address: "add1", scriptType: ScriptType.PubKey, sha256Hash: "hash1");
+        var s2 = new ScriptNode(address: "add2", scriptType: ScriptType.PubKey, sha256Hash: "hash2");
+        var s3 = new ScriptNode(address: "add3", scriptType: ScriptType.PubKey, sha256Hash: "hash3");
+        var s4 = new ScriptNode(address: "add4", scriptType: ScriptType.PubKey, sha256Hash: "hash4");
+
+        var tx1 = new TxNode("tx1");
+        var tx2 = new TxNode("tx2");
+        var tx3 = new TxNode("tx3");
+
+        var mm = long.MaxValue;
+
+        g.TryAddNode(b10);
+        g.TryAddNode(b20);
+        g.TryAddNode(b30);
+        g.TryAddNode(b50);
+
+        g.AddOrUpdateEdge(new S2TEdge(s2, tx1, timestamp: 0, creationHeight: 10, spentHeight: 20, value: 25, txid: "tx_created_1", vout: 1, generated: false));
+        g.AddOrUpdateEdge(new T2SEdge(tx1, s1, timestamp: 0, creationHeight: 20, spentHeight: 50, value: 25, outputIndex: 0));
+
+        g.AddOrUpdateEdge(new S2TEdge(s3, tx2, timestamp: 0, creationHeight: 10, spentHeight: 30, value: 50, txid: "tx_created_2", vout: 1, generated: false));
+        g.AddOrUpdateEdge(new T2SEdge(tx2, s1, timestamp: 0, creationHeight: 30, spentHeight: mm, value: 50, outputIndex: 0));
+
+        g.AddOrUpdateEdge(new S2TEdge(s1, tx3, timestamp: 0, creationHeight: 20, spentHeight: 50, value: 25, txid: "tx_created_3", vout: 0, generated: false));
+        g.AddOrUpdateEdge(new T2SEdge(tx3, s4, timestamp: 0, creationHeight: 50, spentHeight: mm, value: 25, outputIndex: 0));
+        return g;
+    }
+}

--- a/tests/AAB.EBA.GraphDb.Tests/GraphAdapter.cs
+++ b/tests/AAB.EBA.GraphDb.Tests/GraphAdapter.cs
@@ -1,0 +1,96 @@
+﻿using EBA.Blockchains.Bitcoin.GraphModel;
+using EBA.Graph.Bitcoin.Descriptors;
+using EBA.Graph.Model;
+using Neo4j.Driver;
+using INode = EBA.Graph.Model.INode;
+
+namespace AAB.EBA.GraphDb.Tests;
+
+public class GraphAdapter
+{
+    public static async Task ToNeo4jAsync(IDriver driver, GraphBase graph)
+    {
+        await using var session = driver.AsyncSession(x => x.WithDefaultAccessMode(AccessMode.Write));
+
+        await session.ExecuteWriteAsync(async tx =>
+        {
+            foreach (var node in graph.Nodes)
+            {
+                var nodeProps = GetNodeProperties(node);
+                await tx.RunAsync(
+                    $"MERGE " +
+                    $"(n:`{node.NodeKind}` {{ `{node.GetIdPropertyName()}`: $id }}) " +
+                    $"SET n += $props",
+                    new { id = node.Id, props = nodeProps });
+            }
+
+            foreach (var edge in graph.Edges)
+            {
+                var edgeProps = GetEdgeProperties(edge);
+                await tx.RunAsync(
+                    $"MATCH " +
+                    $"(s:`{edge.Source.NodeKind}` {{ `{edge.Source.GetIdPropertyName()}`: $sid }}), " +
+                    $"(t:`{edge.Target.NodeKind}` {{ `{edge.Target.GetIdPropertyName()}`: $tid }}) " +
+                    $"MERGE " +
+                    $"(s)-[r:`{edge.EdgeKind}`]->(t) " +
+                    $"SET r += $props",
+                    new
+                    {
+                        sid = edge.Source.Id,
+                        tid = edge.Target.Id,
+                        props = edgeProps
+                    });
+            }
+        });
+    }
+
+    public static Dictionary<string, object> GetNodeProperties(INode node)
+    {
+        var props = node switch
+        {
+            BlockNode b => BlockNodeDescriptor.StaticMapper.ToProperties(b),
+            ScriptNode s => ScriptNodeDescriptor.StaticMapper.ToProperties(s),
+            TxNode t => TxNodeDescriptor.StaticMapper.ToProperties(t),
+            _ => throw new NotImplementedException($"Descriptor for {node.GetType().Name} not setup")
+        };
+
+        return FormatPropertiesForNeo4j(props);
+    }
+
+    public static Dictionary<string, object> GetEdgeProperties(IEdge<INode, INode> edge)
+    {
+        var props = edge switch
+        {
+            S2TEdge s2t => S2TEdgeDescriptor.StaticMapper.ToProperties(s2t),
+            T2SEdge t2s => T2SEdgeDescriptor.StaticMapper.ToProperties(t2s),
+            C2TEdge c2t => C2TEdgeDescriptor.StaticMapper.ToProperties(c2t),
+            T2TEdge t2t => T2TEdgeDescriptor.StaticMapper.ToProperties(t2t),
+            B2TEdge b2t => B2TEdgeDescriptor.StaticMapper.ToProperties(b2t),
+            B2BEdge b2b => B2BEdgeDescriptor.StaticMapper.ToProperties(b2b),
+            _ => throw new NotImplementedException($"Descriptor for {edge.GetType().Name} not setup")
+        };
+
+        return FormatPropertiesForNeo4j(props);
+    }
+
+    private static Dictionary<string, object> FormatPropertiesForNeo4j(Dictionary<string, object?> props)
+    {
+        var result = new Dictionary<string, object>();
+
+        foreach (var (key, value) in props)
+        {
+            if (value is null) 
+                continue;
+
+            result[key] = value switch
+            {
+                Enum enumValue => enumValue.ToString(),
+                ulong ulongValue => (long)ulongValue,
+                uint uintValue => (long)uintValue,
+                _ => value // keep as-is for other types (e.g., string, long, etc.)
+            };
+        }
+
+        return result;
+    }
+}

--- a/tests/AAB.EBA.GraphDb.Tests/Neo4j/DbFixture.cs
+++ b/tests/AAB.EBA.GraphDb.Tests/Neo4j/DbFixture.cs
@@ -1,0 +1,45 @@
+﻿using EBA.CLI.Config;
+using Neo4j.Driver;
+using Testcontainers.Neo4j;
+
+namespace AAB.EBA.GraphDb.Tests.Neo4j;
+
+public class DbFixture : IAsyncLifetime
+{
+    public Neo4jContainer Neo4jContainer { get; private set; } = null!;
+    public Neo4jOptions Neo4jOptions {  get; private set; } = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        var username = "neo4j";
+        var password = "testpassword";
+        Neo4jContainer = new Neo4jBuilder("neo4j:5")
+            .WithEnvironment("NEO4J_AUTH", $"{username}/{password}")
+            .Build();
+
+        await Neo4jContainer.StartAsync();
+
+        Neo4jOptions = new Neo4jOptions()
+        {
+            User = username,
+            Password = password,
+            Uri = Neo4jContainer.GetConnectionString()
+        };
+
+        // connect to docker
+        var driver = GraphDatabase.Driver(
+            Neo4jContainer.GetConnectionString(), 
+            AuthTokens.Basic(Neo4jOptions.User, Neo4jOptions.Password));
+
+        var testGraph = BitcoinGraphScenarios.GetCommunity1();
+        await GraphAdapter.ToNeo4jAsync(driver, testGraph);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Neo4jContainer != null)
+            await Neo4jContainer.DisposeAsync();
+        
+        GC.SuppressFinalize(this);
+    }
+}

--- a/tests/AAB.EBA.GraphDb.Tests/Neo4j/EdgeTests.cs
+++ b/tests/AAB.EBA.GraphDb.Tests/Neo4j/EdgeTests.cs
@@ -1,0 +1,43 @@
+﻿using EBA.Blockchains.Bitcoin.GraphModel;
+using EBA.CLI.Config;
+using Microsoft.Extensions.Logging.Abstractions;
+using Neo4j.Driver;
+
+namespace AAB.EBA.GraphDb.Tests.Neo4j;
+
+public class EdgeTests : IClassFixture<DbFixture>
+{
+    private readonly Neo4jDb _db;
+    private readonly DbFixture _fixture;
+
+    public EdgeTests(DbFixture fixture)
+    {
+        _fixture = fixture;
+
+        var options = new Options { Neo4j = _fixture.Neo4jOptions };
+
+        var logger = NullLogger<Neo4jDb>.Instance;
+        _db = new Neo4jDb(options, logger);
+    }
+
+    [Fact]
+    public async Task GetEdgesAsyn_ReturnsAllIncomingAndOutgoingEdges_ForTargetNode()
+    {
+        // Act
+        var edges = await _db.GetEdgesAsync(
+            nodeKind: ScriptNode.Kind,
+            nodePropertyKey: "SHA256Hash",
+            nodePropertyValue: "hash1",
+            ct: CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(edges);
+        Assert.Equal(3, edges.Count);
+
+        var relationshipTypes = edges.Select(e => e.Type).ToList();
+        Assert.Contains(T2SEdge.Kind.ToString(), relationshipTypes);
+
+        var edgeValues = edges.Select(e => e.Properties["Value"].As<long>()).ToList();
+        Assert.Contains(50, edgeValues);
+    }
+}

--- a/tests/AAB.EBA.GraphDb.Tests/Neo4j/NodeTests.cs
+++ b/tests/AAB.EBA.GraphDb.Tests/Neo4j/NodeTests.cs
@@ -1,0 +1,52 @@
+﻿using EBA.Blockchains.Bitcoin.GraphModel;
+using EBA.CLI.Config;
+using Microsoft.Extensions.Logging.Abstractions;
+using Neo4j.Driver;
+
+namespace AAB.EBA.GraphDb.Tests.Neo4j;
+
+public class NodeTests : IClassFixture<DbFixture>
+{
+    private readonly Neo4jDb _db;
+    private readonly DbFixture _fixture;
+
+    public NodeTests(DbFixture fixture)
+    {
+        _fixture = fixture;
+
+        var options = new Options { Neo4j = _fixture.Neo4jOptions };
+
+        var logger = NullLogger<Neo4jDb>.Instance;
+        _db = new Neo4jDb(options, logger);
+    }
+
+    [Fact]
+    public async Task GetNodeAsync_WhenExactlyOneNodeExists_ReturnsNode()
+    {
+        // Act
+        var node = await _db.GetNodeAsync(
+            label: ScriptNode.Kind,
+            propertyKey: "SHA256Hash",
+            propertyValue: "hash1",
+            ct: CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(node);
+        Assert.Equal("hash1", node.Properties["SHA256Hash"].As<string>());
+        Assert.Equal("PubKey", node.Properties["ScriptType"].As<string>());
+    }
+
+    [Fact]
+    public async Task GetNodeAsync_WhenNodeDoesNotExist_ReturnsNull()
+    {
+        // Act
+        var node = await _db.GetNodeAsync(
+            label: ScriptNode.Kind,
+            propertyKey: "SHA256Hash",
+            propertyValue: "missing_hash",
+            ct: CancellationToken.None);
+
+        // Assert
+        Assert.Null(node);
+    }
+}

--- a/tests/AAB.EBA.MCP.Tests/AAB.EBA.MCP.Tests.csproj
+++ b/tests/AAB.EBA.MCP.Tests/AAB.EBA.MCP.Tests.csproj
@@ -1,0 +1,36 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Neo4j.Driver" Version="6.0.0" />
+    <PackageReference Include="Testcontainers.Neo4j" Version="4.11.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\EBA\EBA.csproj" />
+    <ProjectReference Include="..\..\src\AAB.EBA.MCP\AAB.EBA.MCP.csproj" />
+    <ProjectReference Include="..\AAB.EBA.GraphDb.Tests\AAB.EBA.GraphDb.Tests.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/AAB.EBA.MCP.Tests/Blockchains/Bitcoin/BitcoinBlockToolsTests.cs
+++ b/tests/AAB.EBA.MCP.Tests/Blockchains/Bitcoin/BitcoinBlockToolsTests.cs
@@ -1,0 +1,39 @@
+﻿using AAB.EBA.GraphDb.Tests;
+using AAB.EBA.MCP.Blockchains.Bitcoin;
+using System.Text.Json.Nodes;
+
+namespace AAB.EBA.MCP.Tests.Blockchains.Bitcoin;
+
+public class BitcoinBlockToolsTests
+{
+    private readonly BitcoinMcpService _mcpService;
+    private readonly BitcoinBlockTools _tools;
+
+    public BitcoinBlockToolsTests()
+    {
+        var mockDb = GraphMockSeeder.CreateMockDb(BitcoinGraphScenarios.GetCommunity1());
+        _mcpService = new BitcoinMcpService(mockDb.Object);
+        _tools = new BitcoinBlockTools(_mcpService);
+    }
+
+    [Fact]
+    public async Task GetBlockInfo_WhenBlockExists_ReturnsCorrectJsonPayload()
+    {
+        // Act
+        var jsonResult = await _tools.GetBlockInfo(height: 10, includeMedianTime: true);
+
+        // Assert
+        Assert.NotNull(jsonResult);
+        Assert.NotEqual("Block at height 10 not found.", jsonResult);
+
+        // Parse the JSON into a JsonNode
+        var node = JsonNode.Parse(jsonResult);
+        Assert.NotNull(node); // Prevents possible null reference on node
+
+        // Access the property and ensure it exists before casting
+        var medianTimeNode = node["MedianTime"];
+        Assert.NotNull(medianTimeNode); // Prevents possible null reference on property
+
+        Assert.Equal(1L, (long)medianTimeNode);
+    }
+}

--- a/tests/AAB.EBA.MCP.Tests/Blockchains/Bitcoin/BitcoinBlockToolsTests.cs
+++ b/tests/AAB.EBA.MCP.Tests/Blockchains/Bitcoin/BitcoinBlockToolsTests.cs
@@ -26,14 +26,11 @@ public class BitcoinBlockToolsTests
         Assert.NotNull(jsonResult);
         Assert.NotEqual("Block at height 10 not found.", jsonResult);
 
-        // Parse the JSON into a JsonNode
         var node = JsonNode.Parse(jsonResult);
-        Assert.NotNull(node); // Prevents possible null reference on node
+        Assert.NotNull(node);
 
-        // Access the property and ensure it exists before casting
         var medianTimeNode = node["MedianTime"];
-        Assert.NotNull(medianTimeNode); // Prevents possible null reference on property
-
+        Assert.NotNull(medianTimeNode);
         Assert.Equal(1L, (long)medianTimeNode);
     }
 }

--- a/tests/AAB.EBA.MCP.Tests/Blockchains/Bitcoin/BitcoinMcpServiceTests.cs
+++ b/tests/AAB.EBA.MCP.Tests/Blockchains/Bitcoin/BitcoinMcpServiceTests.cs
@@ -1,0 +1,94 @@
+﻿using AAB.EBA.GraphDb.Tests;
+using AAB.EBA.MCP.Blockchains.Bitcoin;
+
+namespace AAB.EBA.MCP.Tests.Blockchains.Bitcoin;
+
+public class BitcoinMcpServiceTests
+{
+    [Fact]
+    public async Task GetScriptBalance_WhenNodeExists_ReturnsMappedScriptNode()
+    {
+        // Arrange
+        var graph = BitcoinGraphScenarios.GetCommunity1();
+        var mockDb = GraphMockSeeder.CreateMockDb(graph);
+        //var ops = new Options { Neo4j = new Neo4jOptions { CompressOutput = false } };
+        //var realFactory = new BitcoinStrategyFactory(ops);
+        var service = new BitcoinMcpService(mockDb.Object);
+
+        // Act
+        var balance = await service.GetScriptBalanceAsync("hash1", ct: TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(balance);
+        Assert.Equal(50, balance);
+    }
+
+    [Fact]
+    public async Task GetScriptByAddress_WhenValidAddress_ReturnScriptNode()
+    {
+        // Arrange
+        var graph = BitcoinGraphScenarios.GetCommunity1();
+        var mockDb = GraphMockSeeder.CreateMockDb(graph);
+        //var ops = new Options { Neo4j = new Neo4jOptions { CompressOutput = false } };
+        //var realFactory = new BitcoinStrategyFactory(ops);
+        var service = new BitcoinMcpService(mockDb.Object);
+
+        // Act
+        var scriptNode = await service.GetScriptByAddressAsync("add1", ct: TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(scriptNode);
+        Assert.Equal("add1", scriptNode.Address);
+        Assert.Equal("hash1", scriptNode.SHA256Hash);
+    }
+
+    [Fact]
+    public async Task GetScriptBySHA256_WhenValidSHA256_ReturnScriptNode()
+    {
+        // Arrange
+        var graph = BitcoinGraphScenarios.GetCommunity1();
+        var mockDb = GraphMockSeeder.CreateMockDb(graph);
+        //var ops = new Options { Neo4j = new Neo4jOptions { CompressOutput = false } };
+        //var realFactory = new BitcoinStrategyFactory(ops);
+        var service = new BitcoinMcpService(mockDb.Object);
+
+        // Act
+        var scriptNode = await service.GetScriptBySHA256Async("hash1", ct: TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(scriptNode);
+        Assert.Equal("add1", scriptNode.Address);
+        Assert.Equal("hash1", scriptNode.SHA256Hash);
+    }
+
+    [Fact]
+    public async Task GetScriptTxSummaryStats_WhenValidSHA_ReturnStats()
+    {
+        // Arrange
+        var graph = BitcoinGraphScenarios.GetCommunity1();
+        var mockDb = GraphMockSeeder.CreateMockDb(graph);
+        var service = new BitcoinMcpService(mockDb.Object);
+
+        // Act
+        var stats = await service.GetScriptTxSummaryStatsAsync("hash1", ct: TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(stats);
+        Assert.Equal(3, stats.TxCount);
+
+        Assert.Equal(75, stats.TotalReceived);
+        Assert.Equal(25, stats.TotalSent);
+
+        Assert.Equal(20, stats.FirstReceivedHeight);
+        Assert.Equal(25, stats.FirstReceivedValue);
+
+        Assert.Equal(20, stats.FirstSentHeight);
+        Assert.Equal(25, stats.FirstSentValue);
+
+        Assert.Equal(30, stats.LastReceivedHeight);
+        Assert.Equal(50, stats.LastReceivedValue);
+
+        Assert.Equal(20, stats.LastSentHeight);
+        Assert.Equal(25, stats.LastSentValue);
+    }
+}

--- a/tests/AAB.EBA.MCP.Tests/Blockchains/Bitcoin/BitcoinScriptToolsTests.cs
+++ b/tests/AAB.EBA.MCP.Tests/Blockchains/Bitcoin/BitcoinScriptToolsTests.cs
@@ -1,0 +1,77 @@
+﻿using AAB.EBA.GraphDb.Tests;
+using AAB.EBA.MCP.Blockchains.Bitcoin;
+using System.Text.Json;
+
+namespace AAB.EBA.MCP.Tests.Blockchains.Bitcoin;
+
+public class BitcoinScriptToolsTests
+{
+    private readonly BitcoinMcpService _mcpService;
+    private readonly BitcoinScriptTools _tools;
+
+    public BitcoinScriptToolsTests()
+    {
+        var mockDb = GraphMockSeeder.CreateMockDb(BitcoinGraphScenarios.GetCommunity1());
+        //var options = new Options { Neo4j = new Neo4jOptions { CompressOutput = false } };
+        //var factory = new BitcoinStrategyFactory(options);
+
+        _mcpService = new BitcoinMcpService(mockDb.Object);
+
+        _tools = new BitcoinScriptTools(_mcpService);
+    }
+
+    [Fact]
+    public async Task GetScript_WhenAddressProvidedAndScriptExists_ReturnsCorrectJsonPayload()
+    {
+        // Act
+        var jsonResult = await _tools.GetScript(address: "add1");
+
+        // Assert
+        Assert.NotNull(jsonResult);
+        Assert.DoesNotContain("Did not find", jsonResult);
+
+        using var doc = JsonDocument.Parse(jsonResult);
+        var root = doc.RootElement;
+
+        Assert.Equal("PubKey", root.GetProperty("ScriptType").GetString());
+        Assert.Equal("hash1", root.GetProperty("SHA256Hash").GetString());
+
+        Assert.False(root.TryGetProperty("Address", out _));
+    }
+
+    [Fact]
+    public async Task GetScript_WhenScriptProvidedButScriptDoesNotExist_ReturnsErrorMessage()
+    {
+        // Act
+        var result = await _tools.GetScript("fake_address");
+
+        // Assert
+        Assert.Equal("Did not find a script with given address: fake_address", result);
+    }
+
+    [Fact]
+    public async Task GetScript_WhenScriptHashGivenAndIncludeBalanceTrue_ReturnsJsonWithBalance()
+    {
+        // Act
+        // 'hash1' has two T2S (Credits) edges seeded:
+        // 1. Value = 25 (Spent at height 50)
+        // 2. Value = 50 (Unspent / SpentHeight = long.MaxValue)
+        var result = await _tools.GetScript(sha: "hash1", includeBalance: true);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.DoesNotContain("Did not find", result);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+
+        Assert.Equal("PubKey", root.GetProperty("ScriptType").GetString());
+        Assert.Equal("hash1", root.GetProperty("SHA256Hash").GetString());
+
+        Assert.True(
+            root.TryGetProperty("Balance", out var balanceElement), 
+            "JSON payload is missing the 'Balance' property.");
+
+        Assert.Equal(50, balanceElement.GetInt64());
+    }
+}

--- a/tests/AAB.EBA.MCP.Tests/GraphMockSeeder.cs
+++ b/tests/AAB.EBA.MCP.Tests/GraphMockSeeder.cs
@@ -1,0 +1,144 @@
+﻿using AAB.EBA.GraphDb;
+using AAB.EBA.GraphDb.Tests;
+using EBA.Blockchains.Bitcoin.GraphModel;
+using EBA.Graph.Model;
+using Moq;
+using Neo4j.Driver;
+using INode = EBA.Graph.Model.INode;
+
+namespace AAB.EBA.MCP.Tests;
+
+
+public static class GraphMockSeeder
+{
+    public static Mock<IGraphDb> CreateMockDb(GraphBase graph)
+    {
+        // 1. Transform Domain models into Moq objects using LINQ
+        var neo4jNodes = graph.Nodes.Select(CreateMockNode).ToList();
+        var neo4jRels = graph.Edges.Select(CreateMockRel).ToList();
+
+        var mockDb = new Mock<IGraphDb>();
+
+        // 2. Wire up the read queries
+        mockDb.Setup(db => db.GetNodeAsync(It.IsAny<NodeKind>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+              .ReturnsAsync((NodeKind kind, string key, string value, CancellationToken ct) =>
+                  neo4jNodes.FirstOrDefault(n =>
+                      n.Labels.Contains(kind.ToString()) &&
+                      n.Properties.TryGetValue(key, out var prop) &&
+                      prop?.ToString() == value));
+
+        mockDb.Setup(db => db.GetEdgesAsync(It.IsAny<NodeKind>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<int?>()))
+              .ReturnsAsync((NodeKind kind, string key, string value, CancellationToken ct, int? limit) =>
+              {
+                  // Find the root node's ID first
+                  var rootId = neo4jNodes.FirstOrDefault(n =>
+                      n.Labels.Contains(kind.ToString()) &&
+                      n.Properties.TryGetValue(key, out var prop) &&
+                      prop?.ToString() == value)?.ElementId;
+
+                  if (rootId == null) return []; // C# 12 empty list syntax
+
+                  // Find connected edges
+                  var edges = neo4jRels.Where(r => r.StartNodeElementId == rootId || r.EndNodeElementId == rootId);
+
+                  return limit is > 0 ? edges.Take(limit.Value).ToList() : edges.ToList();
+              });
+
+        return mockDb;
+    }
+
+    // --- Helper Methods to hide Moq boilerplate ---
+
+    private static Neo4j.Driver.INode CreateMockNode(INode domainNode)
+    {
+        var mock = new Mock<Neo4j.Driver.INode>();
+        mock.SetupGet(n => n.ElementId).Returns(domainNode.Id);
+        mock.SetupGet(n => n.Labels).Returns(new List<string> { domainNode.NodeKind.ToString() });
+        mock.SetupGet(n => n.Properties).Returns(GraphAdapter.GetNodeProperties(domainNode));
+        return mock.Object;
+    }
+
+    private static IRelationship CreateMockRel(IEdge<INode, INode> domainEdge)
+    {
+        var mock = new Mock<IRelationship>();
+        mock.SetupGet(r => r.ElementId).Returns($"rel_{domainEdge.Source.Id}_{domainEdge.Relation}_{domainEdge.Target.Id}");
+        mock.SetupGet(r => r.StartNodeElementId).Returns(domainEdge.Source.Id);
+        mock.SetupGet(r => r.EndNodeElementId).Returns(domainEdge.Target.Id);
+        mock.SetupGet(r => r.Type).Returns(domainEdge.Relation.ToString());
+        mock.SetupGet(r => r.Properties).Returns(GraphAdapter.GetEdgeProperties(domainEdge));
+        return mock.Object;
+    }
+}
+/*
+
+public static class GraphMockSeeder
+{
+    public static Mock<IGraphDb> CreateMockDb(GraphBase graph)
+    {
+        var mockDb = new Mock<IGraphDb>();
+        var neo4jNodes = new List<Neo4j.Driver.INode>();
+        var neo4jRels = new List<IRelationship>();
+
+        // ----------------------------------------------------
+        // 1. Translate GraphBase Nodes to Mocked Neo4j Nodes
+        // ----------------------------------------------------
+        foreach (var node in graph.Nodes)
+        {
+            var mockNode = new Mock<Neo4j.Driver.INode>();
+            mockNode.SetupGet(n => n.ElementId).Returns(node.Id);
+            mockNode.SetupGet(n => n.Labels).Returns(new List<string> { node.NodeKind.ToString() });
+
+            // DELEGATE TO THE ADAPTER!
+            var props = GraphAdapter.GetNodeProperties(node);
+            mockNode.SetupGet(n => n.Properties).Returns(props);
+
+            neo4jNodes.Add(mockNode.Object);
+        }
+
+        // ----------------------------------------------------
+        // 2. Translate GraphBase Edges to Mocked Neo4j Rels
+        // ----------------------------------------------------
+        foreach (var edge in graph.Edges)
+        {
+            var mockRel = new Mock<IRelationship>();
+            mockRel.SetupGet(r => r.ElementId).Returns($"rel_{edge.Source.Id}_{edge.Relation}_{edge.Target.Id}");
+            mockRel.SetupGet(r => r.StartNodeElementId).Returns(edge.Source.Id);
+            mockRel.SetupGet(r => r.EndNodeElementId).Returns(edge.Target.Id);
+            mockRel.SetupGet(r => r.Type).Returns(edge.Relation.ToString());
+
+            // DELEGATE TO THE ADAPTER!
+            var props = GraphAdapter.GetEdgeProperties(edge);
+            mockRel.SetupGet(r => r.Properties).Returns(props);
+
+            neo4jRels.Add(mockRel.Object);
+        }
+
+        // ----------------------------------------------------
+        // 3. Wire up the IGraphDb methods to serve the fake data!
+        // ----------------------------------------------------
+        mockDb.Setup(db => db.GetNodeAsync(It.IsAny<NodeKind>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+              .ReturnsAsync((NodeKind kind, string key, string value, CancellationToken ct) =>
+              {
+                  return neo4jNodes.FirstOrDefault(n =>
+                      n.Labels.Contains(kind.ToString()) &&
+                      n.Properties.ContainsKey(key) &&
+                      n.Properties[key]?.ToString() == value);
+              });
+
+        mockDb.Setup(db => db.GetEdgesAsync(It.IsAny<NodeKind>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<int?>()))
+              .ReturnsAsync((NodeKind kind, string key, string value, CancellationToken ct, int? limit) =>
+              {
+                  var rootNode = neo4jNodes.FirstOrDefault(n => n.Labels.Contains(kind.ToString()) && n.Properties.ContainsKey(key) && n.Properties[key]?.ToString() == value);
+                  if (rootNode == null) return new List<IRelationship>();
+
+                  var edges = neo4jRels.Where(r => r.StartNodeElementId == rootNode.ElementId || r.EndNodeElementId == rootNode.ElementId).ToList();
+
+                  if (limit.HasValue && limit.Value > 0)
+                      edges = edges.Take(limit.Value).ToList();
+
+                  return edges;
+              });
+
+        return mockDb;
+    }
+}*/


### PR DESCRIPTION
This PR drafts an MCP service with two draft tools to get info about Bitcoin blocks and scripts (only basic info currently covered). To simplify testing the service, graph database is abstracted into separate project and has its own tests. 

Specifically, the following improvements are implemented in this PR: 
* Add MCP service and its associated tests; currently has two demo tools:
  * block node (basic info)
  * script node (basic info)
* Create a project that contains the base methods of interfacing a graph database.
  * Since `GraphDb` interfaces a graph database, we add associated tests that use `Testcontainers` to enable asserting the interactions with the database. 