### PR TITLE
Remove unix timestamp property of edges

### DIFF
--- a/src/AAB.EBA/Blockchains/Bitcoin/GraphModel/B2BEdge.cs
+++ b/src/AAB.EBA/Blockchains/Bitcoin/GraphModel/B2BEdge.cs
@@ -8,7 +8,6 @@ public class B2BEdge(
         target: target,
         value: 0,
         relation: Kind.Relation,
-        timestamp: 0,
         height: 0)
 {
     public static new EdgeKind Kind => new(BlockNode.Kind, BlockNode.Kind, RelationType.Follows);

--- a/src/AAB.EBA/Blockchains/Bitcoin/GraphModel/B2TEdge.cs
+++ b/src/AAB.EBA/Blockchains/Bitcoin/GraphModel/B2TEdge.cs
@@ -7,18 +7,17 @@ public class B2TEdge : Edge<BlockNode, TxNode>
     public B2TEdge(
         BlockNode source, TxNode target,
         long value, 
-        uint timestamp, long height) :
+        long height) :
         base(
             source: source,
             target: target,
             value: value,
             relation: Kind.Relation,
-            timestamp: timestamp,
             height: height)
     { }    
 
     public B2TEdge Update(long value)
     {
-        return new B2TEdge(Source, Target, Value + value, Timestamp, Height);
+        return new B2TEdge(Source, Target, Value + value, Height);
     }
 }

--- a/src/AAB.EBA/Blockchains/Bitcoin/GraphModel/BlockGraph.cs
+++ b/src/AAB.EBA/Blockchains/Bitcoin/GraphModel/BlockGraph.cs
@@ -72,7 +72,6 @@ public class BlockGraph : BitcoinGraph, IEquatable<BlockGraph>
         TryAddNode(BlockNode);
 
         var v = _coinbaseTxGraph.TxNode;
-        var t = Timestamp;
         var h = Block.Height;
 
         Parallel.ForEach(_txGraphsQueue,
@@ -96,7 +95,7 @@ public class BlockGraph : BitcoinGraph, IEquatable<BlockGraph>
         foreach (var u in _coinbaseTxGraph.Outputs)
         {
             TryGetOrAddEdge(
-                new T2SEdge(v, new ScriptNode(u.ScriptPubKey), t, h, u),
+                new T2SEdge(v, new ScriptNode(u.ScriptPubKey), h, u),
                 out T2SEdge _);
 
             Block.ProfileCreatedOutput(u);
@@ -105,8 +104,8 @@ public class BlockGraph : BitcoinGraph, IEquatable<BlockGraph>
 
         var mintedCoins = miningReward - (long)Block.FeesStats.Sum;
         Block.SetMintedBitcoins(mintedCoins);
-        AddOrUpdateEdge(new C2TEdge(v, mintedCoins, t, h));
-        AddOrUpdateEdge(new B2TEdge(BlockNode, v, mintedCoins, t, h));
+        AddOrUpdateEdge(new C2TEdge(v, mintedCoins, h));
+        AddOrUpdateEdge(new B2TEdge(BlockNode, v, mintedCoins, h));
 
         BlockNode.TripletTypeCount = _edgeLabelCount.ToDictionary(x => x.Key, x => x.Value);
         BlockNode.TripletTypeValueSum = _edgeLabelValueSum.ToDictionary(x => x.Key, x => x.Value);
@@ -116,15 +115,14 @@ public class BlockGraph : BitcoinGraph, IEquatable<BlockGraph>
     {
         var v = txGraph.TxNode;
         var h = Block.Height;
-        var t = Timestamp;
 
         foreach (var u in txGraph.SourceTxes)
-            AddOrUpdateEdge(new T2TEdge(new TxNode(u.Key), v, u.Value, RelationType.Transfers, t, h));
+            AddOrUpdateEdge(new T2TEdge(new TxNode(u.Key), v, u.Value, RelationType.Transfers, h));
 
         foreach (var u in txGraph.Inputs)
         {
             TryGetOrAddEdge(
-                new S2TEdge(new ScriptNode(u.PrevOut.ScriptPubKey), v, t, h, u),
+                new S2TEdge(new ScriptNode(u.PrevOut.ScriptPubKey), v, h, u),
                 out S2TEdge _);
 
             Block.ProfileSpentOutput(u);
@@ -133,7 +131,7 @@ public class BlockGraph : BitcoinGraph, IEquatable<BlockGraph>
         foreach (var u in txGraph.Outputs)
         {
             TryGetOrAddEdge(
-                new T2SEdge(v, new ScriptNode(u.ScriptPubKey), t, h, u), 
+                new T2SEdge(v, new ScriptNode(u.ScriptPubKey), h, u), 
                 out T2SEdge _);
 
             Block.ProfileCreatedOutput(u);
@@ -142,8 +140,8 @@ public class BlockGraph : BitcoinGraph, IEquatable<BlockGraph>
         Block.ProfileTxes(txGraph.InputsCount, txGraph.OutputsCount);
         Block.ProfileFee(txGraph.Fee);
         
-        AddOrUpdateEdge(new T2TEdge(v, _coinbaseTxGraph.TxNode, txGraph.Fee, RelationType.Fee, t, h));
-        AddOrUpdateEdge(new B2TEdge(BlockNode, v, txGraph.TotalInputValue, t, h));
+        AddOrUpdateEdge(new T2TEdge(v, _coinbaseTxGraph.TxNode, txGraph.Fee, RelationType.Fee, h));
+        AddOrUpdateEdge(new B2TEdge(BlockNode, v, txGraph.TotalInputValue, h));
     }
 
     public void AddOrUpdateEdge<T>(T edge)

--- a/src/AAB.EBA/Blockchains/Bitcoin/GraphModel/C2TEdge.cs
+++ b/src/AAB.EBA/Blockchains/Bitcoin/GraphModel/C2TEdge.cs
@@ -3,20 +3,18 @@
 public class C2TEdge(
     TxNode target,
     long value,
-    uint timestamp,
     long height)
     : Edge<CoinbaseNode, TxNode>(
         source: new CoinbaseNode(),
         target: target,
         value: value,
         relation: RelationType.Mints,
-        timestamp: timestamp,
         height: height)
 {
     public new static EdgeKind Kind => new(CoinbaseNode.Kind, TxNode.Kind, RelationType.Mints);
 
     public C2TEdge Update(long value)
     {
-        return new C2TEdge(Target, Value + value, Timestamp, Height);
+        return new C2TEdge(Target, Value + value, Height);
     }
 }

--- a/src/AAB.EBA/Blockchains/Bitcoin/GraphModel/S2TEdge.cs
+++ b/src/AAB.EBA/Blockchains/Bitcoin/GraphModel/S2TEdge.cs
@@ -14,13 +14,11 @@ public class S2TEdge : Edge<ScriptNode, TxNode>
     public S2TEdge(
         ScriptNode source,
         TxNode target,
-        uint timestamp,
         long spentHeight,
         Input spentUTxO)
         : this(
             source: source,
             target: target,
-            timestamp: timestamp,
             spentHeight: spentHeight,
             value: spentUTxO.PrevOut.Value,
             txid: spentUTxO.Txid,
@@ -32,7 +30,6 @@ public class S2TEdge : Edge<ScriptNode, TxNode>
     public S2TEdge(
         ScriptNode source,
         TxNode target,
-        uint timestamp,
         long spentHeight,
         long value,
         string txid,
@@ -44,7 +41,6 @@ public class S2TEdge : Edge<ScriptNode, TxNode>
             target: target,
             value: value,
             relation: Kind.Relation,
-            timestamp: timestamp,
             height: spentHeight)
     {
         Txid = txid;

--- a/src/AAB.EBA/Blockchains/Bitcoin/GraphModel/T2SEdge.cs
+++ b/src/AAB.EBA/Blockchains/Bitcoin/GraphModel/T2SEdge.cs
@@ -13,7 +13,6 @@ public class T2SEdge : Edge<TxNode, ScriptNode>
     public T2SEdge(
         TxNode source,
         ScriptNode target,
-        uint timestamp,
         long creationHeight,
         Output output,
         long spentHeight = long.MaxValue)
@@ -22,7 +21,6 @@ public class T2SEdge : Edge<TxNode, ScriptNode>
             target: target,
             relation: Kind.Relation,
             value: output.Value,
-            timestamp: timestamp,
             height: creationHeight)
     {
         Vout = output.N;
@@ -32,7 +30,6 @@ public class T2SEdge : Edge<TxNode, ScriptNode>
     public T2SEdge(
         TxNode source,
         ScriptNode target,
-        uint timestamp,
         long creationHeight,
         long value,
         int outputIndex,
@@ -42,7 +39,6 @@ public class T2SEdge : Edge<TxNode, ScriptNode>
             target: target,
             relation: Kind.Relation,
             value: value, 
-            timestamp: timestamp, 
             height: creationHeight)
     {
         Vout = outputIndex;

--- a/src/AAB.EBA/Blockchains/Bitcoin/GraphModel/T2TEdge.cs
+++ b/src/AAB.EBA/Blockchains/Bitcoin/GraphModel/T2TEdge.cs
@@ -4,13 +4,12 @@ public class T2TEdge : Edge<TxNode, TxNode>
 {
     public T2TEdge(
         TxNode source, TxNode target,
-        long value, RelationType type, uint timestamp, long height) :
+        long value, RelationType type, long height) :
         base(
             source: source,
             target: target,
             value: value,
             relation: type,
-            timestamp: timestamp,
             height: height)
     { }
 
@@ -39,7 +38,6 @@ public class T2TEdge : Edge<TxNode, TxNode>
             source, target,
             newEdge.Value,
             newEdge.Relation,
-            newEdge.Timestamp,
             newEdge.Height);
     }
 }

--- a/src/AAB.EBA/Graph/Bitcoin/Descriptors/B2TEdgeDescriptor.cs
+++ b/src/AAB.EBA/Graph/Bitcoin/Descriptors/B2TEdgeDescriptor.cs
@@ -23,7 +23,6 @@ public class B2TEdgeDescriptor : IElementDescriptor<B2TEdge>
         return new B2TEdge(
             source: source,
             target: target,
-            timestamp: 0,
             height: _mapper.GetValue(e => e.Height, props),
             value: _mapper.GetValue(e => e.Value, props));
     }

--- a/src/AAB.EBA/Graph/Bitcoin/Descriptors/C2TEdgeDescriptor.cs
+++ b/src/AAB.EBA/Graph/Bitcoin/Descriptors/C2TEdgeDescriptor.cs
@@ -23,7 +23,6 @@ public class C2TEdgeDescriptor : IElementDescriptor<C2TEdge>
         return new C2TEdge(
             target: target,
             value: _mapper.GetValue(e => e.Value, props),
-            timestamp: 0,
             height: _mapper.GetValue(e => e.Height, props));
     }
 }

--- a/src/AAB.EBA/Graph/Bitcoin/Descriptors/S2TEdgeDescriptor.cs
+++ b/src/AAB.EBA/Graph/Bitcoin/Descriptors/S2TEdgeDescriptor.cs
@@ -27,7 +27,6 @@ public class S2TEdgeDescriptor : IElementDescriptor<S2TEdge>
         return new S2TEdge(
             source: source,
             target: target,
-            timestamp: 0,
             creationHeight: _mapper.GetValue(e => e.CreationHeight, props),
             spentHeight: _mapper.GetValue(e => e.SpentHeight, props),
             value: _mapper.GetValue(e => e.Value, props),

--- a/src/AAB.EBA/Graph/Bitcoin/Descriptors/T2SEdgeDescriptor.cs
+++ b/src/AAB.EBA/Graph/Bitcoin/Descriptors/T2SEdgeDescriptor.cs
@@ -25,7 +25,6 @@ public class T2SEdgeDescriptor : IElementDescriptor<T2SEdge>
         return new T2SEdge(
             source: source,
             target: target,
-            timestamp: 0,
             creationHeight: _mapper.GetValue(n => n.CreationHeight, props),
             value: _mapper.GetValue(n => n.Value, props),
             outputIndex: _mapper.GetValue(n => n.Vout, props),

--- a/src/AAB.EBA/Graph/Bitcoin/Descriptors/T2TEdgeDescriptor.cs
+++ b/src/AAB.EBA/Graph/Bitcoin/Descriptors/T2TEdgeDescriptor.cs
@@ -24,7 +24,6 @@ public class T2TEdgeDescriptor : IElementDescriptor<T2TEdge>
         return new T2TEdge(
             source: source,
             target: target,
-            timestamp: 0,
             height: _mapper.GetValue(e => e.Height, props),
             value: _mapper.GetValue(e => e.Value, props),
             type: Enum.Parse<RelationType>(relationType, ignoreCase: true)); 

--- a/src/AAB.EBA/Graph/Model/Edge.cs
+++ b/src/AAB.EBA/Graph/Model/Edge.cs
@@ -12,7 +12,6 @@ public class Edge<TSource, TTarget> : IEdge<TSource, TTarget>, IEquatable<Edge<T
     public TTarget Target { get; }
     public long Value { get; }
     public RelationType Relation { get; }
-    public uint Timestamp { get; }
     public long Height { get; }
 
     private const string _delimiter = "\t";
@@ -22,14 +21,12 @@ public class Edge<TSource, TTarget> : IEdge<TSource, TTarget>, IEquatable<Edge<T
         TTarget target,
         RelationType relation,
         long value,
-        uint timestamp,
         long height)
     {
         Source = source;
         Target = target;
         Value = value;
         Relation = relation;
-        Timestamp = timestamp;
         Height = height;
 
         Id = GetHashCode().ToString();
@@ -65,7 +62,7 @@ public class Edge<TSource, TTarget> : IEdge<TSource, TTarget>, IEquatable<Edge<T
     public string GetHashCode(bool ignoreValue)
     {
         if (ignoreValue)
-            return HashCode.Combine(Source.Id, Target.Id, Relation, Timestamp).ToString();
+            return HashCode.Combine(Source.Id, Target.Id, Relation).ToString();
         else
             return GetHashCode().ToString();
     }
@@ -73,14 +70,14 @@ public class Edge<TSource, TTarget> : IEdge<TSource, TTarget>, IEquatable<Edge<T
     public int GetHashCodeInt(bool ignoreValue)
     {
         if (ignoreValue)
-            return HashCode.Combine(Source.Id, Target.Id, Relation, Timestamp);
+            return HashCode.Combine(Source.Id, Target.Id, Relation);
         else
             return GetHashCode();
     }
 
     public override int GetHashCode()
     {
-        return HashCode.Combine(Source.GetHashCode(), Target.GetHashCode(), Value, Relation, Timestamp);
+        return HashCode.Combine(Source.GetHashCode(), Target.GetHashCode(), Value, Relation);
     }
 
     public bool Equals(Edge<TSource, TTarget>? other)
@@ -90,8 +87,7 @@ public class Edge<TSource, TTarget> : IEdge<TSource, TTarget>, IEquatable<Edge<T
         return Source.Id == other.Source.Id
             && Target.Id == other.Target.Id
             && Value == other.Value
-            && Relation == other.Relation
-            && Timestamp == other.Timestamp;
+            && Relation == other.Relation;
     }
 
     public override bool Equals(object? obj)

--- a/tests/AAB.EBA.GraphDb.Tests/BitcoinGraphScenarios.cs
+++ b/tests/AAB.EBA.GraphDb.Tests/BitcoinGraphScenarios.cs
@@ -40,17 +40,17 @@ public static class BitcoinGraphScenarios
         g.TryAddNode(b30);
         g.TryAddNode(b50);
 
-        g.AddOrUpdateEdge(new B2TEdge(b10, tx1, height: b10.BlockMetadata.Height, value: 25, timestamp: 0));
-        g.AddOrUpdateEdge(new S2TEdge(s02, tx1, creationHeight: 10, spentHeight: 20, value: 25, txid: "tx_created_1", vout: 1, generated: false, timestamp: 0));
-        g.AddOrUpdateEdge(new T2SEdge(tx1, s01, creationHeight: 20, spentHeight: 50, value: 25, outputIndex: 0, timestamp: 0));
+        g.AddOrUpdateEdge(new B2TEdge(b10, tx1, height: b10.BlockMetadata.Height, value: 25));
+        g.AddOrUpdateEdge(new S2TEdge(s02, tx1, creationHeight: 10, spentHeight: 20, value: 25, txid: "tx_created_1", vout: 1, generated: false));
+        g.AddOrUpdateEdge(new T2SEdge(tx1, s01, creationHeight: 20, spentHeight: 50, value: 25, outputIndex: 0));
 
-        g.AddOrUpdateEdge(new B2TEdge(b20, tx2, height: b20.BlockMetadata.Height, value: 50, timestamp: 0));
-        g.AddOrUpdateEdge(new S2TEdge(s03, tx2, creationHeight: 10, spentHeight: 30, value: 50, txid: "tx_created_2", vout: 1, generated: false, timestamp: 0));
-        g.AddOrUpdateEdge(new T2SEdge(tx2, s01, creationHeight: 30, spentHeight: mm, value: 50, outputIndex: 0, timestamp: 0));
+        g.AddOrUpdateEdge(new B2TEdge(b20, tx2, height: b20.BlockMetadata.Height, value: 50));
+        g.AddOrUpdateEdge(new S2TEdge(s03, tx2, creationHeight: 10, spentHeight: 30, value: 50, txid: "tx_created_2", vout: 1, generated: false));
+        g.AddOrUpdateEdge(new T2SEdge(tx2, s01, creationHeight: 30, spentHeight: mm, value: 50, outputIndex: 0));
 
-        g.AddOrUpdateEdge(new B2TEdge(b30, tx3, height: b30.BlockMetadata.Height, value: 25, timestamp: 0));
-        g.AddOrUpdateEdge(new S2TEdge(s01, tx3, creationHeight: 20, spentHeight: 50, value: 25, txid: "tx_created_3", vout: 0, generated: false, timestamp: 0));
-        g.AddOrUpdateEdge(new T2SEdge(tx3, s04, creationHeight: 50, spentHeight: mm, value: 25, outputIndex: 0, timestamp: 0));
+        g.AddOrUpdateEdge(new B2TEdge(b30, tx3, height: b30.BlockMetadata.Height, value: 25));
+        g.AddOrUpdateEdge(new S2TEdge(s01, tx3, creationHeight: 20, spentHeight: 50, value: 25, txid: "tx_created_3", vout: 0, generated: false));
+        g.AddOrUpdateEdge(new T2SEdge(tx3, s04, creationHeight: 50, spentHeight: mm, value: 25, outputIndex: 0));
         return g;
     }
 }


### PR DESCRIPTION
Edges have block height feature, hence, unix timestamp is not needed since it can be derived from block height. Additionally, this feature is not currently set or used. So, this PR drops the unix timestamp feature. 