### PR TITLE
Bug fix getting B2TEdge kind when the community has no edges of this kind

### DIFF
--- a/src/AAB.EBA/Graph/Bitcoin/TraversalAlgorithms/Panorama.cs
+++ b/src/AAB.EBA/Graph/Bitcoin/TraversalAlgorithms/Panorama.cs
@@ -338,13 +338,17 @@ public class Panorama : ITraversalAlgorithm
         {
             var v = (TxNode)txNode;
             var found = false;
-            foreach (var edge in g.EdgesByType[B2TEdge.Kind])
+
+            if (g.EdgesByType.TryGetValue(B2TEdge.Kind, out var b2tEdges))
             {
-                var t = (B2TEdge)edge;
-                if (t.Target.Txid == v.Txid)
+                foreach (var edge in b2tEdges)
                 {
-                    found = true;
-                    break;
+                    var t = (B2TEdge)edge;
+                    if (t.Target.Txid == v.Txid)
+                    {
+                        found = true;
+                        break;
+                    }
                 }
             }
 


### PR DESCRIPTION
There is a corner case where the sampled community in the first pass does not have any edges of type `B2T`, that results in an exception when trying to iterate on edges of this kind while that kind is not defined. (A node/edge kind is defined in the list of nodes/edges after the first instance of that kind is added to the graph). 