### PR TITLE
Deprecate tracking UTxO lifecycle embedded in traversing the chain 

### DIFF
--- a/src/AAB.EBA/Blockchains/Bitcoin/BitcoinChainAgent.cs
+++ b/src/AAB.EBA/Blockchains/Bitcoin/BitcoinChainAgent.cs
@@ -265,22 +265,7 @@ public class BitcoinChainAgent : IDisposable
 
         var mintingTxGraph = new TxGraph(coinbaseTx);
         foreach (var output in coinbaseTx.Outputs)
-        {
             mintingTxGraph.AddOutput(output);
-
-            if (options.Traverse.TrackTxo)
-            {
-                output.TryGetAddress(out string? address);
-                var utxo = new Utxo(
-                    output.ScriptPubKey,
-                    address,
-                    output.Value,
-                    output.ScriptPubKey.ScriptType,
-                    isGenerated: true,
-                    createdInHeight: block.Height);
-                g.Block.TxoLifecycle.TryAdd(utxo.Id, utxo);
-            }
-        }
 
         g.SetCoinbaseTx(mintingTxGraph);
 
@@ -317,53 +302,13 @@ public class BitcoinChainAgent : IDisposable
         foreach (var input in tx.Inputs)
         {
             cT.ThrowIfCancellationRequested();
-
             txGraph.AddInput(input);
-
-            if (options.Traverse.TrackTxo)
-            {
-                var prevOut = input.PrevOut.ConstructedOutput;
-                prevOut.TryGetAddress(out string? address);
-
-                var utxo = new Utxo(
-                    input.PrevOut.ScriptPubKey,
-                    address: address,
-                    value: input.PrevOut.Value,
-                    isGenerated: input.PrevOut.Generated,
-                    scriptType: input.PrevOut.ConstructedOutput.ScriptPubKey.ScriptType,
-                    createdInHeight: input.PrevOut.Height,
-                    spentInHeight: g.Block.Height);
-
-                g.Block.TxoLifecycle.AddOrUpdate(utxo.Id, utxo, (_, oldValue) =>
-                {
-                    oldValue.SpentInHeight = g.Block.Height;
-                    return oldValue;
-                });
-            }
         }
 
         foreach (var output in tx.Outputs)
         {
             cT.ThrowIfCancellationRequested();
-
             txGraph.AddOutput(output);
-
-            if (output.ScriptPubKey.ScriptType != ScriptType.NullData &&
-                output.ScriptPubKey.ScriptType != ScriptType.nonstandard &&
-                options.Traverse.TrackTxo)
-            {
-                output.TryGetAddress(out string? address);
-
-                var utxo = new Utxo(
-                    id: Utxo.GetId(txGraph.TxNode.Txid, output.N),
-                    address: address,
-                    value: output.Value,
-                    scriptType: output.ScriptPubKey.ScriptType,
-                    isGenerated: false,
-                    createdInHeight: g.Block.Height);
-
-                g.Block.TxoLifecycle.TryAdd(utxo.Id, utxo);
-            }
         }
 
         g.Enqueue(txGraph);

--- a/src/AAB.EBA/Blockchains/Bitcoin/BitcoinOrchestrator.cs
+++ b/src/AAB.EBA/Blockchains/Bitcoin/BitcoinOrchestrator.cs
@@ -222,8 +222,6 @@ public class BitcoinOrchestrator : IBlockchainOrchestrator
         using var gBuffer = new PersistentGraphBuffer(
             graphOrchestrator: _host.Services.GetRequiredService<Graph.Bitcoin.BitcoinGraphOrchestrator>(),
             logger: _host.Services.GetRequiredService<ILogger<PersistentGraphBuffer>>(),
-            pTxoLifeCyccleLogger: options.Bitcoin.Traverse.TrackTxo ?_host.Services.GetRequiredService<ILogger<PersistentTxoLifeCycleBuffer>>() : null,
-            txoLifeCycleFilename: options.Bitcoin.Traverse.TrackTxo ? options.Bitcoin.Traverse.TxoFilename : null,
             maxTxoPerFile: options.Bitcoin.Traverse.MaxTxoPerFile,
             options: options,
             semaphore: pgbSemaphore,

--- a/src/AAB.EBA/Blockchains/Bitcoin/ChainModel/Block.cs
+++ b/src/AAB.EBA/Blockchains/Bitcoin/ChainModel/Block.cs
@@ -7,8 +7,6 @@ public class Block : BlockMetadata
     [JsonPropertyName("tx")]
     public List<Tx> Transactions { init; get; } = [];
 
-    public ConcurrentDictionary<string, Utxo> TxoLifecycle { init; get; } = [];
-
     public override DescriptiveStatistics InputCountsStats { get { return new DescriptiveStatistics([.. _inputsCounts]); } }
     private readonly ConcurrentBag<int> _inputsCounts = [];
 

--- a/src/AAB.EBA/CLI/CLI.cs
+++ b/src/AAB.EBA/CLI/CLI.cs
@@ -190,16 +190,6 @@ internal class Cli
                 "be started with REST endpoint enabled."
         };
 
-        var trackTxoOption = new Option<bool>("--track-txo")
-        {
-            Description =
-                "If set, writes the list of txo it sees to a text file, this file will need to further processed" +
-                "and it will also add to storage requirements. " +
-                "Enabling this will slow down the traverse (e.g., from 7h to 11h for the first 500k blocks), and additional storage " +
-                "requirements (e.g., ~140GB for the first 500k blocks) that needs post-traverse processing. Aggregated stats about Txo " +
-                "are recoded in block stats, so set this flag only if you need the complete list of spent and unspent Tx outputs."
-        };
-
         var txoFilenameOption = new Option<string>("--txo-filename")
         {
             Description =
@@ -250,7 +240,6 @@ internal class Cli
             maxBlocksInBufferOption,
             txoFilenameOption,
             skipGraphSerialization,
-            trackTxoOption,
             maxEntriesPerBatch
         };
 
@@ -298,7 +287,6 @@ internal class Cli
                 workingDirOption: _workingDirOption,
                 statusFilenameOption: _statusFilenameOption,
                 maxBlocksInBufferOption: maxBlocksInBufferOption,
-                trackTxoOption: trackTxoOption,
                 txoFilenameOption: txoFilenameOption,
                 skipGraphSerializationOption: skipGraphSerialization,
                 maxEntriesPerBatch: maxEntriesPerBatch);

--- a/src/AAB.EBA/CLI/OptionsBinder.cs
+++ b/src/AAB.EBA/CLI/OptionsBinder.cs
@@ -22,7 +22,6 @@ internal class OptionsBinder
         Option<string>? batchFilenameOption = null,
         Option<int>? maxBlocksInBufferOption = null,
         Option<string>? txoFilenameOption = null,
-        Option<bool>? trackTxoOption = null,
         Option<bool>? skipGraphSerializationOption = null,
         Option<int>? maxEntriesPerBatch = null,
         Option<string>? sortedTxNodeFilenameOption = null,
@@ -56,7 +55,6 @@ internal class OptionsBinder
             BlocksFailedToProcessListFilename = Path.Join(wd, defs.Bitcoin.Traverse.BlocksFailedToProcessListFilename),
             MaxBlocksInBuffer = GetValue(defs.Bitcoin.Traverse.MaxBlocksInBuffer, maxBlocksInBufferOption, c),
             TxoFilename = GetValue(defs.Bitcoin.Traverse.TxoFilename, txoFilenameOption, c, (x) => { return Path.Join(wd, Path.GetFileName(x)); }),
-            TrackTxo = GetValue(defs.Bitcoin.Traverse.TrackTxo, trackTxoOption, c),
             SkipGraphSerialization = GetValue(defs.Bitcoin.Traverse.SkipGraphSerialization, skipGraphSerializationOption, c)
         };
 

--- a/src/AAB.EBA/PersistentObject/PersistentGraphBuffer.cs
+++ b/src/AAB.EBA/PersistentObject/PersistentGraphBuffer.cs
@@ -6,7 +6,6 @@ public class PersistentGraphBuffer : PersistentObjectBase<BlockGraph>, IDisposab
 {
     private readonly Graph.Bitcoin.BitcoinGraphOrchestrator? _graphOrchestrator;
     private readonly ILogger<PersistentGraphBuffer> _logger;
-    private readonly PersistentTxoLifeCycleBuffer? _pTxoLifeCycleBuffer = null;
     private readonly SemaphoreSlim _semaphore;
     private bool _disposed = false;
 
@@ -22,8 +21,6 @@ public class PersistentGraphBuffer : PersistentObjectBase<BlockGraph>, IDisposab
     public PersistentGraphBuffer(
         Graph.Bitcoin.BitcoinGraphOrchestrator? graphOrchestrator,
         ILogger<PersistentGraphBuffer> logger,
-        ILogger<PersistentTxoLifeCycleBuffer>? pTxoLifeCyccleLogger,
-        string? txoLifeCycleFilename,
         int maxTxoPerFile,
         SemaphoreSlim semaphore,
         Options options,
@@ -32,9 +29,6 @@ public class PersistentGraphBuffer : PersistentObjectBase<BlockGraph>, IDisposab
     {
         _graphOrchestrator = graphOrchestrator;
         _logger = logger;
-
-        if (txoLifeCycleFilename != null && pTxoLifeCyccleLogger != null)
-            _pTxoLifeCycleBuffer = new(txoLifeCycleFilename, maxTxoPerFile, pTxoLifeCyccleLogger, ct);
 
         _semaphore = semaphore;
     }
@@ -61,9 +55,6 @@ public class PersistentGraphBuffer : PersistentObjectBase<BlockGraph>, IDisposab
 
         if (_graphOrchestrator != null)
             tasks.Add(_graphOrchestrator.SerializeAsync(obj, default));
-
-        if (_pTxoLifeCycleBuffer != null)
-            tasks.Add(_pTxoLifeCycleBuffer.SerializeAsync(obj.Block.TxoLifecycle.Values, default));
 
         await Task.WhenAll(tasks);
 


### PR DESCRIPTION
UTxO lifecycle was previously tracked as part of traversing the chain. This optional process would create files containing when UTxO was created and spent, which could then be used mostly for statistical investigations. 

In recent changes, EBA now tracks UTxO lifecycle as part of the S2T and T2S edges, which, in addition to tracking and exploring the lifecycle on a graph, it enables using this data for downstream analysis, such as computing market indicators such as NUPL. 

This PR deprecates tracking UTxO lifecycle as part of the traversal process. It removes the optional flag from the `traverse` command, and remove all the related methods.