### PR TITLE
Refactor MCP service to use Streamable HTTP transport

### DIFF
--- a/src/AAB.EBA.MCP/AAB.EBA.MCP.csproj
+++ b/src/AAB.EBA.MCP/AAB.EBA.MCP.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -14,7 +14,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
-    <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
+    <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
     <PackageReference Include="Neo4j.Driver" Version="6.0.0" />
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />

--- a/src/AAB.EBA.MCP/Infrastructure/Startup.cs
+++ b/src/AAB.EBA.MCP/Infrastructure/Startup.cs
@@ -44,6 +44,8 @@ public class Startup
 
         app.MapMcp();
 
+        app.MapGet("/healthz", () => Results.Ok(new { status = "healthy" }));
+
         return app;
     }
 

--- a/src/AAB.EBA.MCP/Infrastructure/Startup.cs
+++ b/src/AAB.EBA.MCP/Infrastructure/Startup.cs
@@ -5,19 +5,50 @@ using AAB.EBA.Graph.Db;
 using AAB.EBA.Graph.Db.Neo4jDb;
 using AAB.EBA.GraphDb;
 using AAB.EBA.MCP.Blockchains.Bitcoin;
-using Microsoft.Extensions.Configuration;
 using Serilog;
+using Serilog.Sinks.SystemConsole.Themes;
 
 namespace AAB.EBA.MCP.Infrastructure;
 
 public class Startup
 {
-    public static HostBuilder GetHostBuilder(Options options)
+    /// <summary>
+    /// Builds and configures a <see cref="WebApplication"/> that exposes the MCP server
+    /// over HTTP using the Streamable-HTTP (SSE) transport.
+    /// Call <c>app.Run()</c> on the returned instance to start Kestrel.
+    /// </summary>
+    public static WebApplication GetWebApplication(string[] args, Options options)
     {
-        var hostBuilder = new HostBuilder();
+        ConfigureSerilog(options);
 
-        var logFilename = options.Logger.LogFilename;
+        var builder = WebApplication.CreateBuilder(args);
 
+        builder.Host.UseSerilog();
+
+        builder.Configuration.Sources.Clear();
+        builder.Configuration
+            .SetBasePath(builder.Environment.ContentRootPath)
+            .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+            .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true, reloadOnChange: true);
+
+        builder.Configuration.GetSection(nameof(Options)).Bind(options);
+
+        ConfigureCommonServices(builder.Services, options);
+
+        builder.Services
+            .AddMcpServer()
+            .WithHttpTransport(options => { options.Stateless = true; })
+            .WithToolsFromAssembly();
+
+        var app = builder.Build();
+
+        app.MapMcp();
+
+        return app;
+    }
+
+    private static void ConfigureSerilog(Options options)
+    {
         Log.Logger =
             new LoggerConfiguration()
             .MinimumLevel.Information()
@@ -26,55 +57,17 @@ public class Startup
                 Serilog.Events.LogEventLevel.Warning)
             .Enrich.FromLogContext()
             .WriteTo.File(
-                path: logFilename,
+                path: options.Logger.LogFilename,
                 rollingInterval: RollingInterval.Hour,
                 outputTemplate: options.Logger.MessageTemplate,
                 shared: true,
                 retainedFileCountLimit: null)
-            /*.WriteTo.Console(
-                theme: AnsiConsoleTheme.Code)*/
+            .WriteTo.Console(
+                theme: AnsiConsoleTheme.Code)
             .CreateLogger();
-        hostBuilder.UseSerilog();
-
-        hostBuilder.ConfigureAppConfiguration(
-            (hostingContext, configuration) =>
-            {
-                ConfigureApp(hostingContext, configuration, options);
-            });
-
-        hostBuilder.ConfigureServices(
-            services =>
-            {
-                ConfigureServices(services, options);
-            });
-
-        return hostBuilder;
     }
 
-    private static void ConfigureApp(
-        HostBuilderContext context,
-        IConfigurationBuilder config,
-        Options options)
-    {
-        config.Sources.Clear();
-        var env = context.HostingEnvironment;
-
-        config
-            .SetBasePath(env.ContentRootPath)
-            .AddJsonFile(
-                $"appsettings.json",
-                optional: true,
-                reloadOnChange: true)
-            .AddJsonFile(
-                $"appsettings.{env.EnvironmentName}.json",
-                optional: true,
-                reloadOnChange: true);
-
-        var configRoot = config.Build();
-        configRoot.GetSection(nameof(Options)).Bind(options);
-    }
-
-    private static void ConfigureServices(IServiceCollection services, Options options)
+    private static void ConfigureCommonServices(IServiceCollection services, Options options)
     {
         services.AddSingleton(options);
         services.AddSingleton<BitcoinMcpService>();
@@ -82,12 +75,8 @@ public class Startup
         services.AddSingleton<IGraphDb, Neo4jDb>();
 
         // TODO: this is a hack. Need it to access strategy factory from the service
-        services.AddSingleton<IGraphDb<BitcoinGraph>, BitcoinNeo4jDb>(); 
+        services.AddSingleton<IGraphDb<BitcoinGraph>, BitcoinNeo4jDb>();
 
         services.AddHttpClient();
-
-        services.AddMcpServer()
-            .WithStdioServerTransport()
-            .WithToolsFromAssembly();
     }
 }

--- a/src/AAB.EBA.MCP/Orchestrator.cs
+++ b/src/AAB.EBA.MCP/Orchestrator.cs
@@ -19,21 +19,13 @@ public class Orchestrator : IDisposable
     public async Task<int> InvokeAsync(string[] args)
     {
         var options = new Options();
-        var host = await SetupAndGetHostAsync(options);
 
-        await host.RunAsync(_cT);
+        Directory.CreateDirectory(options.WorkingDir);
+        var app = Startup.GetWebApplication(args, options);
+        _logger = app.Services.GetRequiredService<ILogger<Orchestrator>>();
+        await app.RunAsync(_cT);
 
         return 0;
-    }
-
-    private async Task<IHost> SetupAndGetHostAsync(Options options)
-    {
-        Directory.CreateDirectory(options.WorkingDir);
-        var hostBuilder = Startup.GetHostBuilder(options);
-        var host = hostBuilder.Build();
-        _logger = host.Services.GetRequiredService<ILogger<Orchestrator>>();
-
-        return host;
     }
 
     public void Dispose()

--- a/src/AAB.EBA.MCP/README.md
+++ b/src/AAB.EBA.MCP/README.md
@@ -1,3 +1,7 @@
-```
-npx @modelcontextprotocol/inspector dotnet AAB.EBA.MCP.dll
+```shell
+# in 1st terminal, start the mcp service:
+dotnet .\src\AAB.EBA.MCP\bin\Debug\net10.0\AAB.EBA.MCP.dll
+
+# in 2nd terminal, run inspector:
+npx @modelcontextprotocol/inspector http://localhost:5000
 ```


### PR DESCRIPTION
Previously, the MCP service used standard input/output (stdio) as its transport protocol (for local development), which is incompatible with hosting it as a standalone microservice. This PR refactors the transport layer to use Streamable HTTP using running the app is as an ASP.NET Core Web API.